### PR TITLE
Fixed legacy dashboard patch to enable grade export

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -40,7 +40,7 @@ from util.file import (
 from util.json_request import JsonResponse, JsonResponseBadRequest
 from util.views import require_global_staff
 from lms.djangoapps.instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
-from lms.djangoapps.grades.new.course_grade_factory import CourseGradeFactory
+from lms.djangoapps.grades.new.course_grade import CourseGradeFactory
 
 from courseware.access import has_access
 from courseware.courses import get_course_with_access, get_course_by_id

--- a/lms/static/js/instructor_dashboard/grade_export.js
+++ b/lms/static/js/instructor_dashboard/grade_export.js
@@ -84,6 +84,11 @@
             });
         }
 
+        InstructorDashboardGradeExport.prototype.onClickTitle = function() {
+            this.$errors.empty();
+            this.$results.empty();
+        };
+
         return InstructorDashboardGradeExport;
     }());
 

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -210,9 +210,13 @@ such that the value can be defined later than this assignment (file load order).
             var $element, constructor;
             constructor = _arg.constructor;
             $element = _arg.$element;
-            return plantTimeout(0, sectionsHaveLoaded.waitFor(function() {
-                return new constructor($element);
-            }));
+            if ($element.length > 0) {
+                return plantTimeout(0, sectionsHaveLoaded.waitFor(function () {
+                    return new constructor($element);
+                }));
+            } else {
+                return null;
+            }
         });
     };
 }).call(this);


### PR DESCRIPTION
#### What are the relevant tickets?

Closes mitocw#74

#### What's this PR do?

Adds legacy grade export functionality back into the instructor dashboard (was removed after the dogwood releases)

#### Where should the reviewer start?

Probably `lms/templates/instructor/instructor_dashboard_2/grade_export.html` and `lms/static/js/instructor_dashboard/grade_export.js`.

#### How should this be manually tested?

- Set the `ENABLE_INSTRUCTOR_GRADE_EXPORT` feature to `True`
- Set a `REMOTE_GRADEBOOK_URL` feature value - you can ask me or Peter for the proper setting here
- Navigate to the `Export Grades` tab for some course (eg: `http://localhost:8000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-grade_export` - make sure you have staff/admin privileges)
- Click the buttons and make sure they work

#### Any background context you want to provide?

1. This PR was originally opened here (https://github.com/mitodl/edx-platform/pull/7), but that was closed in favor of this one due to it being built off of the wrong branch. @blarghmatey created and pushed a patch of those changes on this branch, so this diff is effectively just a correction to that patch.
1. This grade exporting functionality last existed in the dogwood releases (eg: [dogwood.3-3](https://github.com/mitodl/edx-platform/tree/mitx/dogwood.3-3)) in something called the legacy instructor dashboard. As such there is a lot of functionality that was lifted out of the codebase as it existed then. I made several changes to match the patterns that currently exist in the instructor dashboard (the buttons make AJAX requests instead of submitting a general HTML form, etc.), but I tried to be careful not to overdo it with optimizing legacy code.

A few key files from the dogwood release that contained the legacy dashboard functionality:
- https://github.com/mitodl/edx-platform/blob/mitx/dogwood.3-3/lms/templates/courseware/legacy_instructor_dashboard.html
- https://github.com/mitodl/edx-platform/blob/mitx/dogwood.3-3/lms/djangoapps/instructor/views/legacy.py#L211

