### PR TITLE
Fix typo in task name for celery task

### DIFF
--- a/openedx/core/djangoapps/bookmarks/tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tasks.py
@@ -140,7 +140,7 @@ def _update_xblocks_cache(course_key):
                 update_block_cache_if_needed(block_cache, block_data)
 
 
-@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblock_cache')
+@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblocks_cache')
 def update_xblocks_cache(course_id):
     """
     Update the XBlocks cache for a course.


### PR DESCRIPTION
We are getting error logs about 'Module does not define
attribute/class' about this function. The issue is that the task name
was mismatched from the actual function signature.