### PR TITLE
Enabled git auto-export when a course is published

### DIFF
--- a/cms/djangoapps/contentstore/signals.py
+++ b/cms/djangoapps/contentstore/signals.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pytz import UTC
 
 from django.dispatch import receiver
-
+from django.conf import settings
 from xmodule.modulestore.django import modulestore, SignalHandler
 from contentstore.courseware_index import CoursewareSearchIndexer, LibrarySearchIndexer
 from contentstore.proctoring import register_special_exams
@@ -39,12 +39,16 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
 
     # Finally call into the course search subsystem
     # to kick off an indexing action
-
     if CoursewareSearchIndexer.indexing_is_enabled():
         # import here, because signal is registered at startup, but items in tasks are not yet able to be loaded
         from .tasks import update_search_index
-
         update_search_index.delay(unicode(course_key), datetime.now(UTC).isoformat())
+
+    # If the Git auto-export is enabled, push the course changes to Git
+    if settings.FEATURES.get('ENABLE_EXPORT_GIT') and settings.FEATURES.get('ENABLE_GIT_AUTO_EXPORT'):
+        from .tasks import async_export_to_git
+        course_module = modulestore().get_course(course_key)
+        async_export_to_git.delay(course_module)
 
 
 @receiver(SignalHandler.library_updated)


### PR DESCRIPTION
#### What are the relevant tickets?

Closes #8 

#### What's this PR do?

Allows a user to automatically export course content to Git every time they publish

#### Where should the reviewer start?

`cms/djangoapps/contentstore/signals.py`

#### How should this be manually tested?

- Set the `ENABLE_EXPORT_GIT` and `ENABLE_GIT_AUTO_EXPORT` feature flags to `true` (in `cms.env.json`)
  - If you want the export commit to have a specific name and email associated with it, set `GIT_EXPORT_DEFAULT_IDENT` in your settings to a dictionary with values for `'name'` and `'email'`, e.g.: `{'name': 'mygithubusername', 'email': 'myemail@example.com'}`
- Make sure you have a valid file path for the `GIT_REPO_EXPORT_DIR` settings value, and that the path exists on your devstack machine (mine is `/edx/var/edxapp/export_course_repos`)
- Go into a course's advanced settings (e.g.: `http://localhost:8001/settings/advanced/course-v1:mit+gsidebo000+2017_Summer`) and set the `GIT URL` value appropriately for the test repo (e.g.: `"git@github.mit.edu:MITx-Studio2LMS/content-mit-gsidebo000-2017_Summer.git"`)
  - You'll need to use an existing course repo (e.g.: https://github.mit.edu/MITx-Studio2LMS/content-mit-gsidebo000-2017_Summer) or have a new one created. If you're testing from a vagrant machine running devstack, you'll need to generate SSH keys in that machine and add them to your Github account (https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/ - https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account)
- Make a change to the course content, publish, then check the commits in your course repo


