### PR TITLE
Fix for CRI-66 

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -700,7 +700,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         content = {
             'name': self.display_name_with_default,
-            'html': html,
+            'html': html.decode('utf8').encode('ascii', 'xmlcharrefreplace'),
             'weight': self.weight,
         }
 


### PR DESCRIPTION
Courseware that contains python with unicode throws an error in Studio and lms. This used to work fine in dogwood, but was apparently broken in edX JIRA ticket CRI-66 has a good test case and a solution for this.