### PR TITLE
Fixed problem with non-Latin characters in loncapa/python problems 

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -670,7 +670,7 @@ class CapaMixin(CapaFields):
 
         content = {
             'name': self.display_name_with_default,
-            'html': html,
+            'html': html.decode('utf8').encode('ascii', 'xmlcharrefreplace'),
             'weight': self.weight,
         }
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -2315,6 +2315,27 @@ class CapaDescriptorTest(unittest.TestCase):
             }
         )
 
+    def test_indexing_non_latin_problem(self):
+        sample_text_input_problem_xml = textwrap.dedent("""
+            <problem>
+                <script type="text/python">FX1_VAL='Καλημέρα'</script>
+                <p>Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL</p>
+            </problem>
+        """)
+        name = "Non latin Input"
+        descriptor = self._create_descriptor(sample_text_input_problem_xml, name=name)
+        capa_content = " FX1_VAL='Καλημέρα' Δοκιμή με μεταβλητές με Ελληνικούς χαρακτήρες μέσα σε python: $FX1_VAL "
+        self.assertEquals(
+            descriptor.index_dictionary(), {
+                'content_type': CapaDescriptor.INDEX_CONTENT_TYPE,
+                'problem_types': [],
+                'content': {
+                    'display_name': name,
+                    'capa_content': capa_content
+                }
+            }
+        )
+
     def test_indexing_checkboxes_with_hints_and_feedback(self):
         name = "Checkboxes with Hints and Feedback"
         descriptor = self._create_descriptor(self.sample_checkboxes_with_hints_and_feedback_problem_xml, name=name)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/edx-platform/issues/25

#### What's this PR do?
I allows staff/problems to create problems with non latin characters. The solution was originally suggested by @nedbat in https://openedx.atlassian.net/browse/CRI-66

#### How should this be manually tested?
- Open https://openedx.atlassian.net/browse/CRI-66 
- Go to studio and the course, create a empty problem then paste no latin problem from CRI-66  in it
- It will give you error on master
- But if you switch to my branch issue will be fix
