### PR TITLE
when creating a course, set the root_block_id to be the run instead of "course" 

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1903,7 +1903,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 user_id,
                 BlockKey(
                     root_category,
-                    root_block_id or SplitMongoModuleStore.DEFAULT_ROOT_COURSE_BLOCK_ID,
+                    root_block_id or locator.run or SplitMongoModuleStore.DEFAULT_ROOT_COURSE_BLOCK_ID,
                 ),
                 block_fields,
                 definition_id


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #31 

#### What's this PR do?

It changes the behavior of creating courses in split. Now instead of the `root_block_id` being set to 'course' it's set to be the course run. This restores the export behavior of "old" mongo.

However, this does run against edX's architecture for courses, where runs are intended to be instanced of the same content, not independent. 

#### How should this be manually tested?

Create a course with a distinctive run, e.g. "2017_Summer". Export it. Examine the OLX that is output:

- [ ] The course.xml file at the root should contain a course node with a `url_name` attribute with a value that is the same as the course "run," e.g. "2017_Summer" 
- [ ] The policies directory should contain a directory named after the run, e.g. "2017_Summer" 
- [ ] The policy.json file inside the policies directory should have a top level key named "course/{run}" e.g. "course/2017_Summer"
- [ ] The course directory should have an XML file named after the run, e.g. "2017_Summer2.xml"

Now, import the course using the import management command:

```
python manage.py cms --settings=devstack import /edx/src
```

Before this change, you would get a duplicate course, with a run of "course". After the change the course should load over the existing course. 
