### PR TITLE
Add celery tasks for grades computing

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -532,7 +532,9 @@ def create_and_enroll_user(email, username, name, country, password, course_id, 
     except Exception as ex:  # pylint: disable=broad-except
         log.exception(type(ex).__name__)
         errors.append({
-            'username': username, 'email': email, 'response': type(ex).__name__,
+            'username': username,
+            'email': email,
+            'response': type(ex).__name__
         })
     else:
         try:
@@ -2276,7 +2278,10 @@ def list_instructor_tasks(request, course_id):
             tasks = lms.djangoapps.instructor_task.api.get_instructor_task_history(course_id, module_state_key)
     else:
         # If no problem or student, just get currently running tasks
-        tasks = lms.djangoapps.instructor_task.api.get_running_instructor_tasks(course_id)
+        tasks = lms.djangoapps.instructor_task.api.get_running_instructor_tasks(
+            course_id,
+            user=request.user
+        )
 
     response_payload = {
         'tasks': map(extract_task_features, tasks),
@@ -2469,7 +2474,7 @@ def _get_assignment_grade_datatable(course, assignment_name):
     return None, datatable
 
 
-def _do_remote_gradebook(user, course, action, files=None, **kwargs):
+def _do_remote_gradebook(email, course, action, files=None, **kwargs):
     """
     Perform remote gradebook action. Returns error message, response dict.
     """
@@ -2480,8 +2485,10 @@ def _do_remote_gradebook(user, course, action, files=None, **kwargs):
         error_msg = _("Missing required remote gradebook env setting: ") + "REMOTE_GRADEBOOK['URL']"
         return error_msg, {}
     elif not rg_user or not rg_password:
-        error_msg = _("Missing required remote gradebook auth settings: ") + \
-                    "REMOTE_GRADEBOOK_USER, REMOTE_GRADEBOOK_PASSWORD"
+        error_msg = _(
+            "Missing required remote gradebook auth settings: " +
+            "REMOTE_GRADEBOOK_USER, REMOTE_GRADEBOOK_PASSWORD"
+        )
         return error_msg, {}
 
     rg_course_settings = course.remote_gradebook or {}
@@ -2490,7 +2497,7 @@ def _do_remote_gradebook(user, course, action, files=None, **kwargs):
         error_msg = _("No gradebook name defined in course remote_gradebook metadata and no default name set")
         return error_msg, {}
 
-    data = dict(submit=action, gradebook=rg_name, user=user.email, **kwargs)
+    data = dict(submit=action, gradebook=rg_name, user=email, **kwargs)
     resp = requests.post(
         rg_url,
         auth=(rg_user, rg_password),
@@ -2508,7 +2515,7 @@ def _do_remote_gradebook_datatable(user, course, action, files=None, **kwargs):
     """
     Perform remote gradebook action that returns a datatable. Returns error message, datatable dict.
     """
-    error_message, response_json = _do_remote_gradebook(user, course, action, files=files, **kwargs)
+    error_message, response_json = _do_remote_gradebook(user.email, course, action, files=files, **kwargs)
     if error_message:
         return error_message, {}
     response_data = response_json.get('data')  # a list of dicts
@@ -2749,25 +2756,6 @@ def list_remote_assignments(request, course_id):
     })
 
 
-def create_datatable_csv(csv_file, datatable):
-    """Creates a CSV file from the contents of a datatable."""
-    writer = csv.writer(csv_file, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
-    encoded_row = [unicode(s).encode('utf-8') for s in datatable['header']]
-    writer.writerow(encoded_row)
-    for datarow in datatable['data']:
-        # 's' here may be an integer, float (eg score) or string (eg student name)
-        encoded_row = [
-            # If s is already a UTF-8 string, trying to make a unicode
-            # object out of it will fail unless we pass in an encoding to
-            # the constructor. But we can't do that across the board,
-            # because s is often a numeric type. So just do this.
-            s if isinstance(s, str) else unicode(s).encode('utf-8')
-            for s in datarow
-        ]
-        writer.writerow(encoded_row)
-    return csv_file
-
-
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
@@ -2785,7 +2773,7 @@ def display_assignment_grades(request, course_id):
     })
 
 
-@require_POST
+@transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('staff')
@@ -2794,26 +2782,25 @@ def export_assignment_grades_to_rg(request, course_id):
     Exports students' grades for an assignment to the remote gradebook, then returns a
     datatable of those grades
     """
+    assignment_name = request.GET.get('assignment_name', '')
     course_id = CourseLocator.from_string(course_id)
-    course = get_course_by_id(course_id)
-    assignment_name = request.POST.get('assignment_name', '')
-    error_msg, datatable = _get_assignment_grade_datatable(course, assignment_name)
-
-    response_message = ''
-    if not error_msg:
-        file_pointer = StringIO.StringIO()
-        create_datatable_csv(file_pointer, datatable)
-        file_pointer.seek(0)
-        files = {'datafile': file_pointer}
-        error_msg, response_json = _do_remote_gradebook(request.user, course, 'post-grades', files=files)
-        response_message = response_json.get('msg', '')
-
-    return JsonResponse({
-        'errors': error_msg,
-        'message': response_message
-    })
+    try:
+        lms.djangoapps.instructor_task.api.export_grades_to_rgb(
+            request,
+            course_id,
+            assignment_name,
+            request.user.email
+        )
+        success_status = _("Posting grades to remote grade book")
+        return JsonResponse({"status": success_status})
+    except AlreadyRunningError:
+        already_running_status = _("Posting grades to remote grade book."
+                                   " To view the status of the report, see Pending Tasks below."
+                                   " You will be able to download the report when it is complete.")
+        return JsonResponse({"status": already_running_status})
 
 
+@transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('staff')
@@ -2821,21 +2808,18 @@ def export_assignment_grades_csv(request, course_id):
     """
     Creates a CSV of students' grades for an assignment and returns that CSV as an HTTP response
     """
-    course_id = CourseLocator.from_string(course_id)
-    course = get_course_by_id(course_id)
+    course_key = CourseLocator.from_string(course_id)
     assignment_name = request.GET.get('assignment_name', '')
-    error_msg, datatable = _get_assignment_grade_datatable(course, assignment_name)
-    if error_msg:
-        return HttpResponseNotFound(error_msg)
-    else:
-        filename = 'grades {course_id} {name}.csv'.format(
-            course_id=course_id.to_deprecated_string(),
-            name=assignment_name
-        )
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = (u'attachment; filename={0}'.format(filename)).encode('utf-8')
-        create_datatable_csv(response, datatable)
-        return response
+    try:
+        lms.djangoapps.instructor_task.api.export_assignment_grades_csv(request, course_key, assignment_name)
+        success_status = _("The grade report is being created."
+                           " To view the status of the report, see Pending Tasks below.")
+        return JsonResponse({"status": success_status})
+    except AlreadyRunningError:
+        already_running_status = _("The grade report is currently being created."
+                                   " To view the status of the report, see Pending Tasks below."
+                                   " You will be able to download the report when it is complete.")
+        return JsonResponse({"status": already_running_status})
 
 
 @require_POST

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -642,6 +642,12 @@ def _section_remote_gradebook(course):
         'export_assignment_grades_csv_url': reverse(
             'export_assignment_grades_csv', kwargs={'course_id': unicode(course.id)}
         ),
+        'list_instructor_tasks_url': reverse(
+            'list_instructor_tasks', kwargs={'course_id': unicode(course.id)}
+        ),
+        'list_report_downloads_url': reverse(
+            'list_report_downloads', kwargs={'course_id': unicode(course.id)}
+        ),
     }
     return section_data
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -642,8 +642,10 @@ def _section_remote_gradebook(course):
         'export_assignment_grades_csv_url': reverse(
             'export_assignment_grades_csv', kwargs={'course_id': unicode(course.id)}
         ),
-        'list_instructor_tasks_url': reverse(
-            'list_instructor_tasks', kwargs={'course_id': unicode(course.id)}
+        'list_instructor_tasks_url': '{}?include_remote_gradebook=true'.format(
+            reverse(
+                'list_instructor_tasks', kwargs={'course_id': unicode(course.id)}
+            )
         ),
         'list_report_downloads_url': reverse(
             'list_report_downloads', kwargs={'course_id': unicode(course.id)}

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -59,15 +59,16 @@ class SpecificStudentIdMissingError(Exception):
     pass
 
 
-def get_running_instructor_rgb_tasks(course_id, user=None):
+def get_running_instructor_rgb_tasks(course_id, user):
     """
     Returns a query of InstructorTask objects of running tasks for remote grade book.
 
     Used to generate a list of tasks to display on the instructor dashboard.
     """
     # list down remote grade book tasks
+    instructor_tasks = get_running_instructor_tasks(course_id)
     now = datetime.datetime.now()
-    return InstructorTask.objects.filter(
+    rgb_tasks = InstructorTask.objects.filter(
         course_id=course_id,
         task_state__icontains="success",
         task_type=TASK_TYPE_EXPORT_GRADES_TO_RGB,
@@ -75,6 +76,8 @@ def get_running_instructor_rgb_tasks(course_id, user=None):
         updated__gte=now - datetime.timedelta(days=5),
         requester=user
     ).order_by('-updated')[0:3]
+
+    return (instructor_tasks | rgb_tasks).distinct()
 
 
 def get_running_instructor_tasks(course_id):

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -46,6 +46,8 @@ from lms.djangoapps.instructor_task.tasks_helper import (
     generate_students_certificates,
     upload_proctored_exam_results_report,
     upload_ora2_data,
+    generate_assignment_grade_csv,
+    post_grades_to_rgb,
 )
 
 
@@ -300,4 +302,24 @@ def export_ora2_data(entry_id, xmodule_instance_args):
     """
     action_name = ugettext_noop('generated')
     task_fn = partial(upload_ora2_data, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+def export_assignment_grades_csv_task(entry_id, xmodule_instance_args):
+    """
+    Generate a CSV of remote grade book grades.
+    """
+    action_name = ugettext_noop('export_assignment_grades_csv_task')
+    task_fn = partial(generate_assignment_grade_csv, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+def export_grades_to_rgb_task(entry_id, xmodule_instance_args):
+    """
+    Upload grades to remote grade book (RGB).
+    """
+    action_name = ugettext_noop('export_grades_to_rgb')
+    task_fn = partial(post_grades_to_rgb, xmodule_instance_args)
     return run_main_task(entry_id, task_fn, action_name)

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -3,8 +3,10 @@ This file contains tasks that are designed to perform background operations on t
 running state of a course.
 
 """
+import csv
 import json
 import logging
+import requests
 from StringIO import StringIO
 from collections import OrderedDict
 from datetime import datetime
@@ -42,6 +44,10 @@ from certificates.models import (
 from courseware.courses import get_course_by_id, get_problems_in_section
 from lms.djangoapps.grades.context import grading_context_for_course
 from lms.djangoapps.grades.new.course_grade import CourseGradeFactory
+from instructor.views.api import (
+    _do_remote_gradebook,
+    _get_assignment_grade_datatable,
+)
 from courseware.model_data import DjangoKeyValueStore, FieldDataCache
 from courseware.models import StudentModule
 from courseware.module_render import get_module_for_descriptor_internal
@@ -1734,3 +1740,107 @@ def upload_ora2_data(
     TASK_LOG.info(u'%s, Task type: %s, Upload complete.', task_info_string, action_name)
 
     return UPDATE_STATUS_SUCCEEDED
+
+
+def generate_assignment_grade_csv(_xmodule_instance_args, _entry_id, course_id, task_input, action_name):
+    start_time = time()
+    start_date = datetime.now(UTC)
+    num_reports = 1
+    task_progress = TaskProgress(action_name, num_reports, start_time)
+
+    if not task_input['assignment_name']:
+        return _progress_error("Error, assignment name missing", task_progress)
+
+    current_step = {'step': 'Get course from modulestore'}
+    task_progress.update_task_state(extra_meta=current_step)
+    course = get_course_by_id(course_id)
+
+    current_step = {'step': 'Load grades'}
+    task_progress.update_task_state(extra_meta=current_step)
+    __, data_table = _get_assignment_grade_datatable(course, task_input['assignment_name'])
+
+    rows = data_table["data"]
+    task_progress.attempted = task_progress.succeeded = len(rows)
+    task_progress.skipped = task_progress.total - task_progress.attempted
+    rows.insert(0, data_table["header"])
+    current_step = {'step': 'Uploading CSV'}
+    task_progress.update_task_state(extra_meta=current_step)
+
+    # Perform the upload
+    upload_csv_to_report_store(rows, 'grades', course_id, start_date)
+
+    current_step = {'step': 'Uploaded CSV'}
+    return task_progress.update_task_state(extra_meta=current_step)
+
+
+def post_grades_to_rgb(_xmodule_instance_args, _entry_id, course_id, task_input, action_name):
+    start_time = time()
+    num_reports = 1
+    task_progress = TaskProgress(action_name, num_reports, start_time)
+
+    if not task_input['assignment_name']:
+        return _progress_error("Error, assignment name missing", task_progress)
+
+    current_step = {'step': 'Get course from modulestore'}
+    task_progress.update_task_state(extra_meta=current_step)
+    course = get_course_by_id(course_id)
+
+    current_step = {'step': 'Load grades'}
+    task_progress.update_task_state(extra_meta=current_step)
+    __, data_table = _get_assignment_grade_datatable(course, task_input['assignment_name'])
+
+    task_progress.attempted = task_progress.succeeded = len(data_table["data"])
+    task_progress.skipped = task_progress.total - task_progress.attempted
+
+    current_step = {'step': 'Uploading CSV'}
+    task_progress.update_task_state(extra_meta=current_step)
+
+    # Perform the upload
+    file_pointer = StringIO()
+    create_datatable_csv(file_pointer, data_table)
+    file_pointer.seek(0)
+    files = {'datafile': file_pointer}
+
+    error_message, response_json = _do_remote_gradebook(
+        task_input['email_id'],
+        course,
+        'post-grades',
+        files=files,
+    )
+
+    if error_message:
+        return _progress_error(error_message, task_progress)
+
+    current_step = {
+        'step': 'Posted to RGB',
+        'succeeded': 1
+    }
+    task_progress.succeeded = 1
+    return task_progress.update_task_state(extra_meta=current_step)
+
+
+def create_datatable_csv(csv_file, datatable):
+    """Creates a CSV file from the contents of a datatable."""
+    writer = csv.writer(csv_file, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
+    encoded_row = [unicode(s).encode('utf-8') for s in datatable['header']]
+    writer.writerow(encoded_row)
+    for datarow in datatable['data']:
+        # 's' here may be an integer, float (eg score) or string (eg student name)
+        encoded_row = [
+            # If s is already a UTF-8 string, trying to make a unicode
+            # object out of it will fail unless we pass in an encoding to
+            # the constructor. But we can't do that across the board,
+            # because s is often a numeric type. So just do this.
+            s if isinstance(s, str) else unicode(s).encode('utf-8')
+            for s in datarow
+        ]
+        writer.writerow(encoded_row)
+    return csv_file
+
+
+def _progress_error(error_msg, task_progress):
+    task_progress.failed = 1
+    curr_step = {'step': error_msg}
+    task_progress.update_task_state(extra_meta=curr_step)
+    return UPDATE_STATUS_FAILED
+

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -1801,7 +1801,7 @@ def post_grades_to_rgb(_xmodule_instance_args, _entry_id, course_id, task_input,
     file_pointer.seek(0)
     files = {'datafile': file_pointer}
 
-    error_message, response_json = _do_remote_gradebook(
+    error_message, __ = _do_remote_gradebook(
         task_input['email_id'],
         course,
         'post-grades',
@@ -1843,4 +1843,3 @@ def _progress_error(error_msg, task_progress):
     curr_step = {'step': error_msg}
     task_progress.update_task_state(extra_meta=curr_step)
     return UPDATE_STATUS_FAILED
-

--- a/lms/static/js/instructor_dashboard/remote_gradebook.js
+++ b/lms/static/js/instructor_dashboard/remote_gradebook.js
@@ -228,15 +228,11 @@
                             remoteGradebookObj.showErrors(
                                 gettext('Error posting grades to remote grade book. Please try again.')
                             );
-                            return $('.msg-error').css({
-                                display: 'block'
-                            });
+                            remoteGradebookObj.setTaskErrorVisibility(true);
                         },
                         success: function(data) {
                             remoteGradebookObj.showResults(data.status);
-                            return $('.msg-confirm').css({
-                                display: 'block'
-                            });
+                            remoteGradebookObj.setTaskMessageVisibility(true);
                         }
                    });
                 } else {
@@ -252,23 +248,19 @@
                         + assignmentName;
                    remoteGradebookObj.clear_display();
                    return $.ajax({
-                        type: 'GET',
-                        dataType: 'json',
-                        url: url,
-                        error: function() {
-                            remoteGradebookObj.showErrors(
+                       type: 'GET',
+                       dataType: 'json',
+                       url: url,
+                       error: function() {
+                           remoteGradebookObj.showErrors(
                                 gettext('Error generating grades. Please try again.')
-                            );
-                            return $('.msg-error').css({
-                                display: 'block'
-                            });
-                        },
-                        success: function(data) {
-                            remoteGradebookObj.showResults(data.status);
-                            return $('.msg-confirm').css({
-                                display: 'block'
-                            });
-                        }
+                           );
+                           remoteGradebookObj.setTaskErrorVisibility(true);
+                       },
+                       success: function(data) {
+                           remoteGradebookObj.showResults(data.status);
+                           remoteGradebookObj.setTaskMessageVisibility(true);
+                       }
                    });
                 } else {
                     remoteGradebookObj.showErrors(gettext('Assignment name must be specified.'));
@@ -293,12 +285,16 @@
         InstructorDashboardRemoteGradebook.prototype.clear_display = function() {
             this.$errors.empty();
             this.$results.empty();
-            $('.msg-confirm').css({
-                display: 'none'
-            });
-            return $('.msg-error').css({
-                display: 'none'
-            });
+            this.setTaskMessageVisibility(false);
+            this.setTaskErrorVisibility(false);
+        };
+
+        InstructorDashboardRemoteGradebook.prototype.setTaskMessageVisibility = function(visible) {
+            $('.msg-confirm').css({display: visible ? 'block' : 'none'});
+        };
+
+        InstructorDashboardRemoteGradebook.prototype.setTaskErrorVisibility = function(visible) {
+            $('.msg-error').css({display: visible ? 'block' : 'none'});
         };
 
 

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1331,7 +1331,7 @@
     }
     .report-downloads-table {
       .slickgrid {
-        height: 300px;
+        height: auto !important;
         padding: ($baseline/4);
       }
       // Disable horizontal scroll bar when grid only has 1 column. Remove this CSS class when more columns added.
@@ -1380,6 +1380,25 @@
 
   .errors {
     color: rgb(255, 0, 0);
+  }
+
+  .reports-download-container {
+    .data-display-table {
+      .slickgrid {
+        height: 400px;
+      }
+    }
+    .report-downloads-table {
+      .slickgrid {
+        height: auto !important;
+        padding: ($baseline/4);
+      }
+      // Disable horizontal scroll bar when grid only has 1 column. Remove this CSS class when more columns added.
+      .slick-viewport {
+        overflow-x: hidden !important;
+        height: auto !important;
+      }
+    }
   }
 }
 

--- a/lms/templates/instructor/instructor_dashboard_2/remote_gradebook.html
+++ b/lms/templates/instructor/instructor_dashboard_2/remote_gradebook.html
@@ -53,4 +53,27 @@ from openedx.core.djangolib.markup import HTML, Text
 
   <div id="errors" class="errors"></div>
   <div id="results"></div>
+  <br/>
+  <div class="reports-download-container action-type-container">
+    ## Translators: a table of URL links to report files appears after this sentence.
+    <p>
+        ${Text(_("{strong_start}Note{strong_end}: To keep student data secure, you cannot save or email these links for direct access. Copies of links expire within 5 minutes.")).format(
+            strong_start=HTML("<strong>"),
+            strong_end=HTML("</strong>"),
+        )}
+    </p><br>
+
+    <div class="report-downloads-table" id="report-downloads-table" data-endpoint="${ section_data['list_report_downloads_url'] }" ></div>
+  </div>
+%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+  <div class="running-tasks-container action-type-container">
+    <h3 class="hd hd-3">${_("Pending Tasks")}</h3>
+    <div class="running-tasks-section">
+      <p>${_("The status for any active tasks appears in a table below.")} </p>
+      <br />
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
+  </div>
+%endif
 </section>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/405

#### What's this PR do?
It makes given 2 functions of remote grade book(RGB) a celery tasks. 
- Export grades 
- Post grades to RGB 

#### How should this be manually tested?
**Configure**
https://github.com/mitodl/edx-platform/blob/master/docs/en_us/internal/remote_gradebook.md

**Navigate***
Navigate to course => instructor =>  remote_gradebook
http://localhost:8000/courses/(curse.id)/instructor#view-remote_gradebook

**Test by clicking**
Test export gradebook to RGB and export grade csv file of grade

**see status:** of task http://0.0.0.0:8000/admin/instructor_task/instructortask/
@pdpinch 
<img width="1174" alt="screen shot 2017-09-13 at 4 32 15 am" src="https://user-images.githubusercontent.com/10431250/30353001-cf9e09c0-983c-11e7-8da6-1df4ddea6752.png">

<img width="1145" alt="screen shot 2017-09-14 at 5 37 18 pm" src="https://user-images.githubusercontent.com/10431250/30430065-6907d37a-9973-11e7-9b6e-69db19393030.png">
