### PR TITLE
Exposed option to manage static asset imports for studio import

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -285,7 +285,8 @@ def _import_handler(request, courselike_key, root_name, successful_url, context_
                         settings.GITHUB_REPO_ROOT, [dirpath],
                         load_error_modules=False,
                         static_content_store=contentstore(),
-                        target_id=courselike_key
+                        target_id=courselike_key,
+                        do_import_static=getattr(settings, 'WEB_IMPORT_STATIC', True)
                     )
 
                 new_location = courselike_items[0].location

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -103,6 +103,9 @@ if STATIC_URL_BASE:
         STATIC_URL += "/"
     STATIC_URL += EDX_PLATFORM_REVISION + "/"
 
+# Make import of static assets into Mongo modulestore configurable
+WEB_IMPORT_STATIC = ENV_TOKENS.get('WEB_IMPORT_STATIC', True)
+
 # DEFAULT_COURSE_ABOUT_IMAGE_URL specifies the default image to show for courses that don't provide one
 DEFAULT_COURSE_ABOUT_IMAGE_URL = ENV_TOKENS.get('DEFAULT_COURSE_ABOUT_IMAGE_URL', DEFAULT_COURSE_ABOUT_IMAGE_URL)
 


### PR DESCRIPTION
When importing courses via studio it is hard-coded to do static asset imports, whereas git imports have a configurable parameter. I exposed that as a settings value so that we can avoid the need to remove static directories during import.