### PR TITLE
Ficus: Allowed creation of multiple tasks for RGB

### DIFF
--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -10,6 +10,7 @@ import logging
 import datetime
 from collections import Counter
 import hashlib
+import uuid
 
 from celery.states import READY_STATES
 
@@ -561,7 +562,7 @@ def export_assignment_grades_csv(request, course_key, assignment_name):
     task_input = {
         "assignment_name": assignment_name
     }
-    task_key = ""
+    task_key = uuid.uuid4()
     TASK_LOG.debug("Submitting download grades task")
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
@@ -576,6 +577,6 @@ def export_grades_to_rgb(request, course_key, assignment_name, email):
         "assignment_name": assignment_name,
         "email_id": email
     }
-    task_key = ""
+    task_key = uuid.uuid4()
     TASK_LOG.debug("Submitting grades to RGB task")
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -10,7 +10,6 @@ import logging
 import datetime
 from collections import Counter
 import hashlib
-import uuid
 
 from celery.states import READY_STATES
 
@@ -562,7 +561,7 @@ def export_assignment_grades_csv(request, course_key, assignment_name):
     task_input = {
         "assignment_name": assignment_name
     }
-    task_key = uuid.uuid4()
+    task_key = hashlib.md5(assignment_name).hexdigest()
     TASK_LOG.debug("Submitting download grades task")
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
@@ -577,6 +576,6 @@ def export_grades_to_rgb(request, course_key, assignment_name, email):
         "assignment_name": assignment_name,
         "email_id": email
     }
-    task_key = uuid.uuid4()
+    task_key = hashlib.md5(assignment_name).hexdigest()
     TASK_LOG.debug("Submitting grades to RGB task")
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/468

#### What's this PR do?
It allow staff user to create multiple RGB tasks in parallel.

#### How should this be manually tested?
- set RGB on course
- attempt export grates and export grades to rgb, they must run parallel

@pdpinch 