### PR TITLE
Improved logging around git auto-export

### DIFF
--- a/cms/djangoapps/contentstore/git_export_utils.py
+++ b/cms/djangoapps/contentstore/git_export_utils.py
@@ -70,6 +70,7 @@ def cmd_log(cmd, cwd):
 def export_to_git(course_id, repo, user='', rdir=None):
     """Export a course to git."""
     # pylint: disable=too-many-statements
+    log.info("Starting git export (course id: %s)", course_id)
 
     if not GIT_REPO_EXPORT_DIR:
         raise GitExportError(GitExportError.NO_EXPORT_DIR)
@@ -181,3 +182,5 @@ def export_to_git(course_id, repo, user='', rdir=None):
     except subprocess.CalledProcessError as ex:
         log.exception('Error running git push command: %r', ex.output)
         raise GitExportError(GitExportError.CANNOT_PUSH)
+
+    log.info("Finished git export (course id: %s)", course_id)

--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -51,6 +51,9 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
     if settings.FEATURES.get('ENABLE_EXPORT_GIT') and settings.FEATURES.get('ENABLE_GIT_AUTO_EXPORT'):
         from contentstore.tasks import async_export_to_git
         course_module = modulestore().get_course(course_key)
+        log.info(
+            'Course published with auto-export enabled. Starting export... (course id: %s)', course_module.id
+        )
         async_export_to_git.delay(course_module)
 
 

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -202,12 +202,15 @@ def async_export_to_git(course_module, user=None):
     Exports a course to Git.
     """
     try:
+        LOGGER.debug('Starting async course content export to git (course id: %s)', course_module.id)
         export_to_git(course_module.id, course_module.giturl, user=user)
-        LOGGER.debug('Exported course content to git: %s', course_module.id)
     except GitExportError as ex:
-        LOGGER.error('Failed to export course content to git: %s', ex)
+        LOGGER.error('Failed async course content export to git (course id: %s): %s', course_module.id, ex)
     except Exception as ex:
-        LOGGER.error('Unknown error occured while exporting course content to git: %s', ex)
+        LOGGER.error(
+            'Unknown error occured during async course content export to git (course id: %s): %s',
+            course_module.id, ex
+        )
 
 
 class CourseExportTask(UserTask):  # pylint: disable=abstract-method


### PR DESCRIPTION
Closes https://github.com/mitodl/salt-ops/issues/485

This PR adds some more detailed logging along the git auto-export code path
