### PR TITLE
Fixed failing asynchronous git export

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -50,11 +50,10 @@ def listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable=
     # If the Git auto-export is enabled, push the course changes to Git
     if settings.FEATURES.get('ENABLE_EXPORT_GIT') and settings.FEATURES.get('ENABLE_GIT_AUTO_EXPORT'):
         from contentstore.tasks import async_export_to_git
-        course_module = modulestore().get_course(course_key)
         log.info(
-            'Course published with auto-export enabled. Starting export... (course id: %s)', course_module.id
+            'Course published with auto-export enabled. Starting export... (course id: %s)', course_key
         )
-        async_export_to_git.delay(course_module)
+        async_export_to_git.delay(unicode(course_key))
 
 
 @receiver(SignalHandler.library_updated)

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -197,10 +197,12 @@ def push_course_update_task(course_key_string, course_subscription_id, course_di
 
 
 @task()
-def async_export_to_git(course_module, user=None):
+def async_export_to_git(course_key_string, user=None):
     """
     Exports a course to Git.
     """
+    course_key = CourseKey.from_string(course_key_string)
+    course_module = modulestore().get_course(course_key)
     try:
         LOGGER.debug('Starting async course content export to git (course id: %s)', course_module.id)
         export_to_git(course_module.id, course_module.giturl, user=user)


### PR DESCRIPTION
Asynchronous git export, which is called when git auto-export is enabled, was failing due to an issue with the type of data being passed into the celery task. This PR fixes that issue.

Here's an explanation of the issue pasted from Slack: 

> celery needs to serialize the parameters that you pass to the tasks when `CELERY_ALWAYS_EAGER` is set to false, and the default serializer is JSON. since i was running with that var set to true, i never saw this, but since it's async in QA, it tries to serialize a course_module, which can't be JSON serialized. we don't get a stack trace because the signals are sent using `Signal.send_robust`