### PR TITLE
Fixed circular import for remote gradebook functionality

### DIFF
--- a/common/lib/safe_lxml/safe_lxml/etree.py
+++ b/common/lib/safe_lxml/safe_lxml/etree.py
@@ -7,11 +7,16 @@ It also includes a safer XMLParser.
 For processing xml always prefer this over using lxml.etree directly.
 """
 
+# Names are imported into this module so that it can be a stand-in for
+# lxml.etree.  The names are not used here, so disable the pylint warning.
+# pylint: disable=unused-import, wildcard-import, unused-wildcard-import
+
+from lxml.etree import XMLParser as _XMLParser
+from lxml.etree import *
+from lxml.etree import _Element, _ElementTree
+
 # This should be imported after lxml.etree so that it overrides the following attributes.
 from defusedxml.lxml import XML, fromstring, parse
-from lxml.etree import XMLParser as _XMLParser
-from lxml.etree import *  # pylint: disable=wildcard-import, unused-wildcard-import; pylint: disable=unused-import
-from lxml.etree import _Element, _ElementTree
 
 
 class XMLParser(_XMLParser):  # pylint: disable=function-redefined

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -64,7 +64,13 @@ from lms.djangoapps.instructor.enrollment import (
     unenroll_email
 )
 from lms.djangoapps.instructor.views import INVOICE_KEY
-from lms.djangoapps.instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
+from lms.djangoapps.instructor.views.instructor_task_helpers import (
+    do_remote_gradebook,
+    do_remote_gradebook_datatable,
+    extract_email_features,
+    extract_task_features,
+    get_assignment_grade_datatable
+    )
 from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError
 from lms.djangoapps.instructor_task.models import ReportStore
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -2467,117 +2473,6 @@ def problem_grade_report(request, course_id):
         })
 
 
-def _get_assignment_grade_datatable(course, assignment_name, task_progress=None):
-    """
-    Returns a datatable of students' grades for an assignment in the given course
-    """
-    if not assignment_name:
-        return _("No assignment name given"), {}
-
-    row_data = []
-    current_step = {'step': 'Calculating Grades'}
-    student_counter = 0
-    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course.id)
-    total_enrolled_students = enrolled_students.count()
-
-    for student, course_grade, error in CourseGradeFactory().iter(users=enrolled_students, course=course):
-        # Periodically update task status (this is a cache write)
-        student_counter += 1
-        if task_progress is not None:
-            task_progress.update_task_state(extra_meta=current_step)
-            task_progress.attempted += 1
-
-        log.info(
-            u'%s, Current step: %s, Grade calculation in-progress for students: %s/%s',
-            assignment_name,
-            current_step,
-            student_counter,
-            total_enrolled_students
-        )
-
-        if course_grade and not error:
-            matching_assignment_grade = next(
-                ifilter(
-                    lambda grade_section: grade_section['label'] == assignment_name,
-                    course_grade.summary['section_breakdown']
-                ), {}
-            )
-            row_data.append([student.email, matching_assignment_grade.get('percent', 0)])
-            if task_progress is not None:
-                task_progress.succeeded += 1
-        else:
-            if task_progress is not None:
-                task_progress.failed += 1
-
-    if task_progress is not None:
-        task_progress.succeeded = student_counter
-        task_progress.skipped = task_progress.total - task_progress.attempted
-        current_step = {'step': 'Calculated Grades for {} students'.format(student_counter)}
-        task_progress.update_task_state(extra_meta=current_step)
-
-    datatable = dict(
-        header=[_('External email'), assignment_name],
-        data=row_data,
-        title=_('Grades for assignment "{name}"').format(name=assignment_name)
-    )
-    return None, datatable
-
-
-def _do_remote_gradebook(email, course, action, files=None, **kwargs):
-    """
-    Perform remote gradebook action. Returns error message, response dict.
-    """
-    rg_url = settings.REMOTE_GRADEBOOK.get('URL')
-    rg_user = settings.REMOTE_GRADEBOOK_USER
-    rg_password = settings.REMOTE_GRADEBOOK_PASSWORD
-    if not rg_url:
-        error_msg = _("Missing required remote gradebook env setting: ") + "REMOTE_GRADEBOOK['URL']"
-        return error_msg, {}
-    elif not rg_user or not rg_password:
-        error_msg = _(
-            "Missing required remote gradebook auth settings: " +
-            "REMOTE_GRADEBOOK_USER, REMOTE_GRADEBOOK_PASSWORD"
-        )
-        return error_msg, {}
-
-    rg_course_settings = course.remote_gradebook or {}
-    rg_name = rg_course_settings.get('name') or settings.REMOTE_GRADEBOOK.get('DEFAULT_NAME')
-    if not rg_name:
-        error_msg = _("No gradebook name defined in course remote_gradebook metadata and no default name set")
-        return error_msg, {}
-
-    data = dict(submit=action, gradebook=rg_name, user=email, **kwargs)
-    resp = requests.post(
-        rg_url,
-        auth=(rg_user, rg_password),
-        data=data,
-        files=files,
-        verify=False
-    )
-    if not resp.ok:
-        error_header = _("Error communicating with gradebook server at {url}").format(url=rg_url)
-        return '<p>{error_header}</p>{content}'.format(error_header=error_header, content=resp.content), {}
-    return None, json.loads(resp.content)
-
-
-def _do_remote_gradebook_datatable(user, course, action, files=None, **kwargs):
-    """
-    Perform remote gradebook action that returns a datatable. Returns error message, datatable dict.
-    """
-    error_message, response_json = _do_remote_gradebook(user.email, course, action, files=files, **kwargs)
-    if error_message:
-        return error_message, {}
-    response_data = response_json.get('data')  # a list of dicts
-    if not response_data or response_data == [{}]:
-        return _("Remote gradebook returned no results for this action ({}).").format(action), {}
-    datatable = dict(
-        header=response_data[0].keys(),
-        data=[x.values() for x in response_data],
-        retdata=response_data,
-    )
-    return None, datatable
-
-
 def get_course_assignment_labels(course):
     """
     Gets a list labels for all assignments in a course based on the assignment type and the
@@ -2683,7 +2578,7 @@ def get_remote_gradebook_sections(request, course_id):
     """
     course_id = CourseLocator.from_string(course_id)
     course = get_course_by_id(course_id)
-    error_msg, datatable = _do_remote_gradebook_datatable(request.user, course, 'get-sections')
+    error_msg, datatable = do_remote_gradebook_datatable(request.user, course, 'get-sections')
     return JsonResponse({
         'errors': error_msg,
         'data': [datarow[0] for datarow in datatable.get('data', [])]
@@ -2701,7 +2596,7 @@ def list_matching_remote_enrolled_students(request, course_id):
     """
     course_id = CourseLocator.from_string(course_id)
     course = get_course_by_id(course_id)
-    error_msg, rg_datatable = _do_remote_gradebook_datatable(request.user, course, 'get-membership')
+    error_msg, rg_datatable = do_remote_gradebook_datatable(request.user, course, 'get-membership')
     datatable = {}
     if not error_msg:
         enrolled_students = CourseEnrollment.objects.users_enrolled_in(course.id)
@@ -2729,7 +2624,7 @@ def list_remote_students_in_section(request, course_id):
     section_name = request.POST.get('section_name', '')
     course_id = CourseLocator.from_string(course_id)
     course = get_course_by_id(course_id)
-    error_msg, datatable = _do_remote_gradebook_datatable(request.user, course, 'get-membership', section=section_name)
+    error_msg, datatable = do_remote_gradebook_datatable(request.user, course, 'get-membership', section=section_name)
     datatable['title'] = _('Enrolled Students in Section in Remote Gradebook')
     return JsonResponse({
         'errors': error_msg,
@@ -2749,7 +2644,7 @@ def add_enrollments_using_remote_gradebook(request, course_id):
     section_name = request.POST.get('section_name', '')
     course_id = CourseLocator.from_string(course_id)
     course = get_course_by_id(course_id)
-    error_msg, rg_datatable = _do_remote_gradebook_datatable(request.user, course, 'get-membership', section=section_name)
+    error_msg, rg_datatable = do_remote_gradebook_datatable(request.user, course, 'get-membership', section=section_name)
     datatable = {}
     if not error_msg:
         datarow = []
@@ -2798,7 +2693,7 @@ def list_remote_assignments(request, course_id):
     """
     course_id = CourseLocator.from_string(course_id)
     course = get_course_by_id(course_id)
-    error_msg, datatable = _do_remote_gradebook_datatable(request.user, course, 'get-assignments')
+    error_msg, datatable = do_remote_gradebook_datatable(request.user, course, 'get-assignments')
     datatable['title'] = _('Remote Gradebook Assignments')
     return JsonResponse({
         'errors': error_msg,
@@ -2816,7 +2711,7 @@ def display_assignment_grades(request, course_id):
     """
     course_id = CourseLocator.from_string(course_id)
     course = get_course_by_id(course_id)
-    error_msg, datatable = _get_assignment_grade_datatable(course, request.POST.get('assignment_name', ''))
+    error_msg, datatable = get_assignment_grade_datatable(course, request.POST.get('assignment_name', ''))
     return JsonResponse({
         'errors': error_msg,
         'datatable': datatable

--- a/lms/djangoapps/instructor/views/instructor_task_helpers.py
+++ b/lms/djangoapps/instructor/views/instructor_task_helpers.py
@@ -4,12 +4,17 @@ tasks.
 """
 import json
 import logging
+import requests
 
+from itertools import ifilter
+from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 
 from bulk_email.models import CourseEmail
 from lms.djangoapps.instructor_task.views import get_task_completion_info
+from lms.djangoapps.grades.new.course_grade_factory import CourseGradeFactory
+from student.models import CourseEnrollment
 from util.date_utils import get_default_time_display
 
 log = logging.getLogger(__name__)
@@ -134,3 +139,113 @@ def extract_task_features(task):
     task_feature_dict['task_message'] = task_message
 
     return task_feature_dict
+
+def get_assignment_grade_datatable(course, assignment_name, task_progress=None):
+    """
+    Returns a datatable of students' grades for an assignment in the given course
+    """
+    if not assignment_name:
+        return _("No assignment name given"), {}
+
+    row_data = []
+    current_step = {'step': 'Calculating Grades'}
+    student_counter = 0
+    enrolled_students = CourseEnrollment.objects.users_enrolled_in(course.id)
+    total_enrolled_students = enrolled_students.count()
+
+    for student, course_grade, error in CourseGradeFactory().iter(users=enrolled_students, course=course):
+        # Periodically update task status (this is a cache write)
+        student_counter += 1
+        if task_progress is not None:
+            task_progress.update_task_state(extra_meta=current_step)
+            task_progress.attempted += 1
+
+        log.info(
+            u'%s, Current step: %s, Grade calculation in-progress for students: %s/%s',
+            assignment_name,
+            current_step,
+            student_counter,
+            total_enrolled_students
+        )
+
+        if course_grade and not error:
+            matching_assignment_grade = next(
+                ifilter(
+                    lambda grade_section: grade_section['label'] == assignment_name,
+                    course_grade.summary['section_breakdown']
+                ), {}
+            )
+            row_data.append([student.email, matching_assignment_grade.get('percent', 0)])
+            if task_progress is not None:
+                task_progress.succeeded += 1
+        else:
+            if task_progress is not None:
+                task_progress.failed += 1
+
+    if task_progress is not None:
+        task_progress.succeeded = student_counter
+        task_progress.skipped = task_progress.total - task_progress.attempted
+        current_step = {'step': 'Calculated Grades for {} students'.format(student_counter)}
+        task_progress.update_task_state(extra_meta=current_step)
+
+    datatable = dict(
+        header=[_('External email'), assignment_name],
+        data=row_data,
+        title=_('Grades for assignment "{name}"').format(name=assignment_name)
+    )
+    return None, datatable
+
+
+def do_remote_gradebook(email, course, action, files=None, **kwargs):
+    """
+    Perform remote gradebook action. Returns error message, response dict.
+    """
+    rg_url = settings.REMOTE_GRADEBOOK.get('URL')
+    rg_user = settings.REMOTE_GRADEBOOK_USER
+    rg_password = settings.REMOTE_GRADEBOOK_PASSWORD
+    if not rg_url:
+        error_msg = _("Missing required remote gradebook env setting: ") + "REMOTE_GRADEBOOK['URL']"
+        return error_msg, {}
+    elif not rg_user or not rg_password:
+        error_msg = _(
+            "Missing required remote gradebook auth settings: " +
+            "REMOTE_GRADEBOOK_USER, REMOTE_GRADEBOOK_PASSWORD"
+        )
+        return error_msg, {}
+
+    rg_course_settings = course.remote_gradebook or {}
+    rg_name = rg_course_settings.get('name') or settings.REMOTE_GRADEBOOK.get('DEFAULT_NAME')
+    if not rg_name:
+        error_msg = _("No gradebook name defined in course remote_gradebook metadata and no default name set")
+        return error_msg, {}
+
+    data = dict(submit=action, gradebook=rg_name, user=email, **kwargs)
+    resp = requests.post(
+        rg_url,
+        auth=(rg_user, rg_password),
+        data=data,
+        files=files,
+        verify=False
+    )
+    if not resp.ok:
+        error_header = _("Error communicating with gradebook server at {url}").format(url=rg_url)
+        return '<p>{error_header}</p>{content}'.format(error_header=error_header, content=resp.content), {}
+    return None, json.loads(resp.content)
+
+
+def do_remote_gradebook_datatable(user, course, action, files=None, **kwargs):
+    """
+    Perform remote gradebook action that returns a datatable. Returns error message, datatable dict.
+    """
+    error_message, response_json = do_remote_gradebook(user.email, course, action, files=files, **kwargs)
+    if error_message:
+        return error_message, {}
+    response_data = response_json.get('data')  # a list of dicts
+    if not response_data or response_data == [{}]:
+        return _("Remote gradebook returned no results for this action ({}).").format(action), {}
+    datatable = dict(
+        header=response_data[0].keys(),
+        data=[x.values() for x in response_data],
+        retdata=response_data,
+    )
+    return None, datatable

--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -20,9 +20,9 @@ from pytz import UTC
 from courseware.courses import get_course_by_id
 from instructor_analytics.basic import get_proctored_exam_results
 from instructor_analytics.csvs import format_dictlist
-from instructor.views.api import (
-    _do_remote_gradebook,
-    _get_assignment_grade_datatable,
+from instructor.views.instructor_task_helpers import (
+    do_remote_gradebook,
+    get_assignment_grade_datatable,
 )
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
@@ -308,7 +308,7 @@ def generate_assignment_grade_csv(_xmodule_instance_args, _entry_id, course_id, 
 
     current_step = {'step': 'Load grades'}
     task_progress.update_task_state(extra_meta=current_step)
-    __, data_table = _get_assignment_grade_datatable(course, task_input['assignment_name'])
+    __, data_table = get_assignment_grade_datatable(course, task_input['assignment_name'])
 
     rows = data_table["data"]
     task_progress.attempted = task_progress.succeeded = len(rows)
@@ -338,7 +338,7 @@ def post_grades_to_rgb(_xmodule_instance_args, _entry_id, course_id, task_input,
 
     current_step = {'step': 'Load grades'}
     task_progress.update_task_state(extra_meta=current_step)
-    __, data_table = _get_assignment_grade_datatable(course, task_input['assignment_name'])
+    __, data_table = get_assignment_grade_datatable(course, task_input['assignment_name'])
 
     task_progress.attempted = task_progress.succeeded = len(data_table["data"])
     task_progress.skipped = task_progress.total - task_progress.attempted
@@ -352,7 +352,7 @@ def post_grades_to_rgb(_xmodule_instance_args, _entry_id, course_id, task_input,
     file_pointer.seek(0)
     files = {'datafile': file_pointer}
 
-    error_message, __ = _do_remote_gradebook(
+    error_message, __ = do_remote_gradebook(
         task_input['email_id'],
         course,
         'post-grades',

--- a/requirements/edx/pre.txt
+++ b/requirements/edx/pre.txt
@@ -15,3 +15,8 @@ numpy==1.6.2
 
 # Needed for meliae
 Cython==0.21.2
+
+
+# Ginkgo only!
+Django==1.8.18
+git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
When merging in the patches to enable asynchronous grade export to remote gradebooks a complex circular import loop was created. This PR refactors the last functions in the loop into a different module to break the circle and allow for the workers to properly start up.