### PR TITLE
Updated isinstance check to verify unicode values as well

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -226,7 +226,7 @@ from openedx.core.lib.courses import course_image_url
             <li class="important-dates-item">
               <span class="icon fa fa-calendar" aria-hidden="true"></span>
               <p class="important-dates-item-title">${_("Classes Start")}</p>
-              % if isinstance(course_start_date, str):
+              % if isinstance(course_start_date, (str, unicode)):
                   <span class="important-dates-item-text start-date">${course_start_date}</span>
               % else:
                   <%
@@ -245,7 +245,7 @@ from openedx.core.lib.courses import course_image_url
             <li class="important-dates-item">
                 <span class="icon fa fa-calendar" aria-hidden="true"></span>
                 <p class="important-dates-item-title">${_("Classes End")}</p>
-                    % if isinstance(course_end_date, str):
+                    % if isinstance(course_end_date, (str, unicode)):
                         <span class="important-dates-item-text final-date">${course_end_date}</span>
                     % else:
                       <%


### PR DESCRIPTION
The isinstance check is only verifying whether the object is of `str` type, which isn't the same as `unicode` in Python 2. Adding the `unicode` type to the isinstance comparison will prevent attempts at parsing it via `strftime`.