### PR TITLE
Fixed unthemed error pages

### DIFF
--- a/cms/djangoapps/contentstore/views/error.py
+++ b/cms/djangoapps/contentstore/views/error.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring,unused-argument
 
 import functools
+import crum
 
 from django.http import HttpResponse, HttpResponseNotFound, HttpResponseServerError
 
@@ -28,6 +29,21 @@ def jsonable_error(status=500, message="The Studio servers encountered an error"
     return outer
 
 
+def fix_crum_request(func):
+    """
+    A decorator that ensures that the 'crum' package (a middleware that stores and fetches the current request in
+    thread-local storate) can correctly fetch the current request. Under certain conditions, the current request cannot
+    be fetched by crum (e.g.: when HTTP errors are raised in our views via 'raise Http404', et. al.). This decorator
+    manually sets the current request for crum if it cannot be fetched.
+    """
+    @functools.wraps(func)
+    def wrapper(request, *args, **kwargs):
+        if not crum.get_current_request():
+            crum.set_current_request(request=request)
+        return func(request, *args, **kwargs)
+    return wrapper
+
+
 @jsonable_error(404, "Resource not found")
 def not_found(request):
     return render_to_response('error.html', {'error': '404'})
@@ -38,11 +54,13 @@ def server_error(request):
     return render_to_response('error.html', {'error': '500'})
 
 
+@fix_crum_request
 @jsonable_error(404, "Resource not found")
 def render_404(request):
     return HttpResponseNotFound(render_to_string('404.html', {}, request=request))
 
 
+@fix_crum_request
 @jsonable_error(500, "The Studio servers encountered an error")
 def render_500(request):
     return HttpResponseServerError(render_to_string('500.html', {}, request=request))


### PR DESCRIPTION
Issue: https://github.com/mitodl/salt-ops/issues/482

We were experiencing a UI bug where error pages under certain circumstances were being displayed without the appropriate theme. This PR adds a sort of 'patch' that allows the error views to correctly fetch the current request object, which makes it possible to identify the active theme.

To test locally:
- Check out this branch in `edx-platform`
- Enable the mitx theme (edX theme guide: http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/changing_appearance/theming/enable_themes.html; MITx theme: https://github.com/mitodl/mitx-theme)
- At line 59 in `edx-platform/pavelib/servers.py` (`run_server` function), a list called `args` is created. This represents the Django `runserver` command with the appropriate arguments added. Replace `--traceback` with `--insecure`. This lets you see actual styled error pages when running locally instead of a stack trace page.
- Run studio (e.g.: `paver devstack studio --settings=devstack --fast`)
- Navigate to `https://localhost:<your_lms_port>/export_output/abcdefghijklmnop`. The site theme should still be active (MITx logo at the top left, etc.)
  