### PR TITLE
Refactored XBlockAside rendering and added support for student view

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -9,7 +9,6 @@ from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from opaque_keys.edx.keys import UsageKey
 from xblock.core import XBlock
 from xblock.django.request import django_to_webob_request, webob_to_django_response
@@ -17,10 +16,12 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock.plugin import PluginMissingError
 from xblock.runtime import Mixologist
 
-from contentstore.utils import get_lms_link_for_item, get_xblock_aside_instance, reverse_course_url
+from contentstore.utils import get_lms_link_for_item, reverse_course_url
 from contentstore.views.helpers import get_parent_xblock, is_unit, xblock_type_display_name
 from contentstore.views.item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
 from edxmako.shortcuts import render_to_response
+from openedx.core.djangoapps.common_views.xblock import invoke_xblock_aside_handler
+from openedx.core.lib.xblock_utils import is_xblock_aside
 from student.auth import has_course_author_access
 from xblock_django.api import authorable_xblocks, disabled_xblocks
 from xblock_django.models import XBlockStudioConfigurationFlag
@@ -440,29 +441,23 @@ def component_handler(request, usage_key_string, handler, suffix=''):
         :class:`django.http.HttpResponse`: The response from the handler, converted to a
             django response
     """
-
     usage_key = UsageKey.from_string(usage_key_string)
+    if is_xblock_aside(usage_key):
+        return invoke_xblock_aside_handler(request, usage_key, handler, suffix=suffix)
+
     # Let the module handle the AJAX
     req = django_to_webob_request(request)
 
-    asides = []
-
     try:
-        if isinstance(usage_key, (AsideUsageKeyV1, AsideUsageKeyV2)):
-            descriptor = modulestore().get_item(usage_key.usage_key)
-            aside_instance = get_xblock_aside_instance(usage_key)
-            asides = [aside_instance] if aside_instance else []
-            resp = aside_instance.handle(handler, req, suffix)
-        else:
-            descriptor = modulestore().get_item(usage_key)
-            descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
-            resp = descriptor.handle(handler, req, suffix)
+        descriptor = modulestore().get_item(usage_key)
+        descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
+        resp = descriptor.handle(handler, req, suffix)
     except NoSuchHandlerError:
         log.info("XBlock %s attempted to access missing handler %r", descriptor, handler, exc_info=True)
         raise Http404
 
     # unintentional update to handle any side effects of handle call
     # could potentially be updating actual course data or simply caching its values
-    modulestore().update_item(descriptor, request.user.id, asides=asides)
+    modulestore().update_item(descriptor, request.user.id)
 
     return webob_to_django_response(resp)

--- a/common/static/common/js/xblock/core.js
+++ b/common/static/common/js/xblock/core.js
@@ -11,6 +11,9 @@
         } else {
             selector = '.' + blockClass;
         }
+        // After an element is initialized, a class is added to it. To avoid repeat initialization, no
+        // elements with that class should be selected.
+        selector += ':not(.xblock-initialized)';
         return $(element).immediateDescendents(selector).map(function(idx, elem) {
             return initializer(elem, requestToken);
         }).toArray();
@@ -112,6 +115,7 @@
         initializeAside: function(element) {
             var blockUsageId = $(element).data('block-id');
             var blockElement = $(element).siblings('[data-usage-id="' + blockUsageId + '"]')[0];
+
             return constructBlock(element, [blockElement, initArgs(element)]);
         },
 

--- a/openedx/core/djangoapps/common_views/xblock.py
+++ b/openedx/core/djangoapps/common_views/xblock.py
@@ -9,6 +9,12 @@ import mimetypes
 from django.conf import settings
 from django.http import Http404, HttpResponse
 from xblock.core import XBlock
+from xblock.django.request import django_to_webob_request, webob_to_django_response
+from xblock.exceptions import NoSuchHandlerError
+
+from openedx.core.lib.xblock_utils import get_aside_from_xblock
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -31,3 +37,32 @@ def xblock_resource(request, block_type, uri):  # pylint: disable=unused-argumen
 
     mimetype, _ = mimetypes.guess_type(uri)
     return HttpResponse(content, content_type=mimetype)
+
+
+def invoke_xblock_aside_handler(request, usage_key, handler, suffix=''):
+    """
+    Dispatches a request to a handler specified in an XBlockAside, then returns the response.
+    """
+    req = django_to_webob_request(request)
+    try:
+        descriptor = modulestore().get_item(usage_key.usage_key)
+        aside_instance = get_aside_from_xblock(descriptor, usage_key.aside_type)
+        asides = [aside_instance] if aside_instance else []
+        resp = aside_instance.handle(handler, req, suffix)
+    except ItemNotFoundError:
+        log.warning(u'Unable to load xblock wrapped by aside [usage_key: %s]', usage_key.usage_key)
+        raise Http404
+    except NoSuchHandlerError:
+        log.info(
+            "XBlockAside %s attempted to access missing handler %r",
+            descriptor,
+            handler,
+            exc_info=True
+        )
+        raise Http404
+
+    # unintentional update to handle any side effects of handle call
+    # could potentially be updating actual course data or simply caching its values
+    modulestore().update_item(descriptor, request.user.id, asides=asides)
+
+    return webob_to_django_response(resp)

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -24,6 +24,7 @@ from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.exceptions import InvalidScopeError
 from xblock.scorable import ScorableXBlockMixin
+from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 
 from xmodule.seq_module import SequenceModule
 from xmodule.vertical_block import VerticalBlock
@@ -500,3 +501,32 @@ def xblock_resource_pkg(block):
         return module_name
 
     return module_name.rsplit('.', 1)[0]
+
+
+def is_xblock_aside(usage_key):
+    """
+    Returns True if the given usage key is for an XBlock aside
+
+    Args:
+        usage_key (opaque_keys.edx.keys.UsageKey): A usage key
+
+    Returns:
+        bool: Whether or not the usage key is an aside key type
+    """
+    return isinstance(usage_key, (AsideUsageKeyV1, AsideUsageKeyV2))
+
+
+def get_aside_from_xblock(xblock, aside_type):
+    """
+    Gets an instance of an XBlock aside from the XBlock that it's decorating
+
+    Args:
+        xblock (xblock.core.XBlock): The XBlock that the desired aside is decorating
+        aside_type (str): The aside type
+
+    Returns:
+        xblock.core.XBlockAside: Instance of an xblock aside
+    """
+    for aside in xblock.runtime.get_asides(xblock):
+        if aside.scope_ids.block_type == aside_type:
+            return aside


### PR DESCRIPTION
This PR adds support for aside rendering in the LMS student view, and refactors the aside code to use the same code path in LMS/Studio for dispatching requests to the handlers defined in the aside.