### PR TITLE
Fixed RGB task message

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -363,10 +363,8 @@ def post_grades_to_rgb(_xmodule_instance_args, _entry_id, course_id, task_input,
         return _progress_error(error_message, task_progress)
 
     current_step = {
-        'step': 'Posted to RGB',
-        'succeeded': 1
+        'step': 'Posted to RGB'
     }
-    task_progress.succeeded = 1
     return task_progress.update_task_state(extra_meta=current_step)
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/549

#### What's this PR do?
It fixed the progress message which is currently reset in code. It removes redundant code 

#### How should this be manually tested?
- Configure RGB
- test post grades and download grades 

@pdpinch 

<img width="1168" alt="screen shot 2018-03-05 at 8 44 23 pm" src="https://user-images.githubusercontent.com/10431250/36984170-0f741af6-20b6-11e8-84e9-e50b7fcf469d.png">
