### PR TITLE
Fixed aside studio view

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -449,17 +449,16 @@ def component_handler(request, usage_key_string, handler, suffix=''):
         if is_xblock_aside(usage_key):
             # Get the descriptor for the block being wrapped by the aside (not the aside itself)
             descriptor = modulestore().get_item(usage_key.usage_key)
-            aside_instance = get_aside_from_xblock(descriptor, usage_key.aside_type)
-            aside_instance.runtime = StudioEditModuleRuntime(request.user)
-            asides = [aside_instance]
-            resp = aside_instance.handle(handler, req, suffix)
+            handler_descriptor = get_aside_from_xblock(descriptor, usage_key.aside_type)
+            asides = [handler_descriptor]
         else:
             descriptor = modulestore().get_item(usage_key)
-            descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
+            handler_descriptor = descriptor
             asides = []
-            resp = descriptor.handle(handler, req, suffix)
+        handler_descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
+        resp = handler_descriptor.handle(handler, req, suffix)
     except NoSuchHandlerError:
-        log.info("XBlock %s attempted to access missing handler %r", descriptor, handler, exc_info=True)
+        log.info("XBlock %s attempted to access missing handler %r", handler_descriptor, handler, exc_info=True)
         raise Http404
 
     # unintentional update to handle any side effects of handle call

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -52,7 +52,7 @@ from models.settings.course_grading import CourseGradingModel
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.lib.gating import api as gating_api
-from openedx.core.lib.xblock_utils import request_token, wrap_xblock
+from openedx.core.lib.xblock_utils import request_token, wrap_xblock, wrap_xblock_aside
 from static_replace import replace_static_urls
 from student.auth import has_studio_read_access, has_studio_write_access
 from util.date_utils import get_default_time_display
@@ -321,6 +321,14 @@ def xblock_view_handler(request, usage_key_string, view_name):
             'StudioRuntime',
             usage_id_serializer=unicode,
             request_token=request_token(request),
+        ))
+
+        xblock.runtime.wrappers_asides.append(partial(
+            wrap_xblock_aside,
+            'StudioRuntime',
+            usage_id_serializer=unicode,
+            request_token=request_token(request),
+            extra_classes=['wrapper-comp-plugins']
         ))
 
         if view_name in (STUDIO_VIEW, VISIBILITY_VIEW):

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -87,6 +87,10 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'common
                     this.$('.modal-window-title').text(title);
                     if (editorView.getDataEditor() && editorView.getMetadataEditor()) {
                         this.addDefaultModes();
+                        // If the plugins content element exists, add a button to reveal it.
+                        if (this.$('.wrapper-comp-plugins').length > 0) {
+                            this.addModeButton('plugins', gettext('Plugins'));
+                        }
                         this.selectMode(editorView.mode);
                     }
                 }

--- a/cms/static/js/views/xblock_editor.js
+++ b/cms/static/js/views/xblock_editor.js
@@ -2,9 +2,9 @@
  * XBlockEditorView displays the authoring view of an xblock, and allows the user to switch between
  * the available modes.
  */
-define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata', 'js/collections/metadata',
+define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'js/views/xblock', 'js/views/metadata', 'js/collections/metadata',
     'jquery.inputnumber'],
-    function($, _, gettext, XBlockView, MetadataView, MetadataCollection) {
+    function($, _, gettext, BaseView, XBlockView, MetadataView, MetadataCollection) {
         var XBlockEditorView = XBlockView.extend({
             // takes XBlockInfo as a model
 
@@ -24,6 +24,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
 
             initializeEditors: function() {
                 var metadataEditor,
+                    pluginEl,
                     defaultMode = 'editor';
                 metadataEditor = this.createMetadataEditor();
                 this.metadataEditor = metadataEditor;
@@ -34,6 +35,12 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
                         defaultMode = 'settings';
                     }
                     this.selectMode(defaultMode);
+                }
+                pluginEl = this.$('.wrapper-comp-plugins');
+                if (pluginEl.length > 0) {
+                    this.pluginEditor = new BaseView({
+                        el: pluginEl
+                    });
                 }
             },
 
@@ -85,6 +92,10 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
 
             getMetadataEditor: function() {
                 return this.metadataEditor;
+            },
+
+            getPluginEditor: function() {
+                return this.pluginEditor;
             },
 
             /**
@@ -144,14 +155,17 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
             },
 
             selectMode: function(mode) {
-                var showEditor = mode === 'editor',
-                    dataEditor = this.getDataEditor(),
-                    metadataEditor = this.getMetadataEditor();
+                var dataEditor = this.getDataEditor(),
+                    metadataEditor = this.getMetadataEditor(),
+                    pluginEditor = this.getPluginEditor();
                 if (dataEditor) {
-                    this.setEditorActivation(dataEditor, showEditor);
+                    this.setEditorActivation(dataEditor, mode === 'editor');
                 }
                 if (metadataEditor) {
-                    this.setEditorActivation(metadataEditor.$el, !showEditor);
+                    this.setEditorActivation(metadataEditor.$el, mode === 'settings');
+                }
+                if (pluginEditor) {
+                    this.setEditorActivation(pluginEditor.$el, mode === 'plugins');
                 }
                 this.mode = mode;
             },

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -276,7 +276,8 @@
             margin-left: ($baseline/2);
 
             .editor-button,
-            .settings-button {
+            .settings-button,
+            .plugins-button {
               @extend %btn-secondary-gray;
               @extend %t-copy-sub1;
 

--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -887,6 +887,14 @@
   }
 }
 
+.wrapper-comp-plugins {
+  display: none;
+
+  &.is-active {
+    display: block;
+  }
+}
+
 
 // +Case - Special Xblock Type Overrides
 // ====================

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -154,7 +154,8 @@ def wrap_xblock_aside(
         context,                        # pylint: disable=unused-argument
         usage_id_serializer,
         request_token,                   # pylint: disable=redefined-outer-name
-        extra_data=None
+        extra_data=None,
+        extra_classes=None
 ):
     """
     Wraps the results of rendering an XBlockAside view in a standard <section> with identifying
@@ -170,6 +171,7 @@ def wrap_xblock_aside(
     :param request_token: An identifier that is unique per-request, so that only xblocks
         rendered as part of this request will have their javascript initialized.
     :param extra_data: A dictionary with extra data values to be set on the wrapper
+    :param extra_classes: A list with extra classes to be set on the wrapper element
     """
 
     if extra_data is None:
@@ -186,6 +188,8 @@ def wrap_xblock_aside(
         ),
         'xblock_asides-v1'
     ]
+    if extra_classes:
+        css_classes.extend(extra_classes)
 
     if frag.js_init_fn:
         data['init'] = frag.js_init_fn


### PR DESCRIPTION
This PR introduces a set of changes that make the aside studio view work correctly. If an aside defines a studio view, its contents are now rendered in a new tab in the block editor modal. This can be tested with the rapid-response aside