### PR TITLE
Enabled git auto-export upon course publish

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -4,10 +4,10 @@ from datetime import datetime
 from functools import wraps
 import logging
 
+from django.conf import settings
 from django.core.cache import cache
 from django.dispatch import receiver
 from pytz import UTC
-from django.conf import settings
 from contentstore.courseware_index import CoursewareSearchIndexer, LibrarySearchIndexer
 from contentstore.proctoring import register_special_exams
 from lms.djangoapps.grades.tasks import compute_all_grades_for_course


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/edx-platform/issues/87

#### What's this PR do?
Allows a user to automatically export course content to Git every time they publish

#### Where should the reviewer start?
`cms/djangoapps/contentstore/signals.py`

@pdpinch 
#### How should this be manually tested?
- Set the `ENABLE_EXPORT_GIT` and `ENABLE_GIT_AUTO_EXPORT` feature flags to `true` (in `cms.env.json`)
  - If you want the export commit to have a specific name and email associated with it, set `GIT_EXPORT_DEFAULT_IDENT` in your settings to a dictionary with values for `'name'` and `'email'`, e.g.: `{'name': 'mygithubusername', 'email': 'myemail@example.com'}`
- Make sure you have a valid file path for the `GIT_REPO_EXPORT_DIR` settings value, and that the path exists on your devstack machine (mine is `/edx/var/edxapp/export_course_repos`)
- Go into a course's advanced settings (e.g.: `http://localhost:8001/settings/advanced/course-v1:mit+gsidebo000+2017_Summer`) and set the `GIT URL` value appropriately for the test repo (e.g.: `"git@github.com:amir-qayyum-khan/test_edx_course.git"`)
  - You'll need to use an existing course repo (e.g.: `git@github.com:amir-qayyum-khan/test_edx_course.git`) or have a new one created. If you're testing from a vagrant machine running devstack, you'll need to generate SSH keys in that machine and add them to your Github account (https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/ - https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account)
- Make a change to the course content, publish, then check the commits in your course repo


