### PR TITLE
Enhance couses page performance in system admin page

### DIFF
--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -3,7 +3,9 @@ Provides a function for importing a git repository into the lms
 instance when using a mongo modulestore
 """
 
+from dateutil import parser
 import logging
+import json
 import os
 import re
 import StringIO
@@ -175,19 +177,8 @@ def switch_branch(branch, rdir):
         raise GitImportErrorCannotBranch()
 
 
-def add_repo(repo, rdir_in, branch=None):
-    """
-    This will add a git repo into the mongo modulestore.
-    If branch is left as None, it will fetch the most recent
-    version of the current branch.
-    """
-    # pylint: disable=too-many-statements
-
-    git_repo_dir = getattr(settings, 'GIT_REPO_DIR', DEFAULT_GIT_REPO_DIR)
-    git_import_static = getattr(settings, 'GIT_IMPORT_STATIC', True)
-    git_import_python_lib = getattr(settings, 'GIT_IMPORT_PYTHON_LIB', True)
-    python_lib_filename = getattr(settings, 'PYTHON_LIB_FILENAME', DEFAULT_PYTHON_LIB_FILENAME)
-
+def open_mongo_connection():
+    """open mongo connection for edit"""
     # Set defaults even if it isn't defined in settings
     mongo_db = {
         'host': 'localhost',
@@ -202,6 +193,35 @@ def add_repo(repo, rdir_in, branch=None):
         for config_item in ['host', 'user', 'password', 'db', 'port']:
             mongo_db[config_item] = settings.MONGODB_LOG.get(
                 config_item, mongo_db[config_item])
+
+    # store import-command-run output in mongo
+    mongouri = 'mongodb://{user}:{password}@{host}:{port}/{db}'.format(**mongo_db)
+
+    mdb = None
+    try:
+        if mongo_db['user'] and mongo_db['password']:
+            mdb = mongoengine.connect(mongo_db['db'], host=mongouri)
+        else:
+            mdb = mongoengine.connect(mongo_db['db'], host=mongo_db['host'], port=mongo_db['port'])
+    except mongoengine.connection.ConnectionError:
+        log.exception('Unable to connect to mongodb to save log, please '
+                      'check MONGODB_LOG settings')
+
+    return mdb
+
+
+def add_repo(repo, rdir_in, branch=None):
+    """
+    This will add a git repo into the mongo modulestore.
+    If branch is left as None, it will fetch the most recent
+    version of the current branch.
+    """
+    # pylint: disable=too-many-statements
+
+    git_repo_dir = getattr(settings, 'GIT_REPO_DIR', DEFAULT_GIT_REPO_DIR)
+    git_import_static = getattr(settings, 'GIT_IMPORT_STATIC', True)
+    git_import_python_lib = getattr(settings, 'GIT_IMPORT_PYTHON_LIB', True)
+    python_lib_filename = getattr(settings, 'PYTHON_LIB_FILENAME', DEFAULT_PYTHON_LIB_FILENAME)
 
     if not os.path.isdir(git_repo_dir):
         raise GitImportErrorNoDir(git_repo_dir)
@@ -237,9 +257,10 @@ def add_repo(repo, rdir_in, branch=None):
         switch_branch(branch, rdirp)
 
     # get commit id
-    cmd = ['git', 'log', '-1', '--format=%H', ]
+    cmd = ['git', 'log', '-1', '--format=format:{ "commit": "%H", "author": "%an %ae", "date": "%ad"}', ]
     try:
-        commit_id = cmd_log(cmd, cwd=rdirp)
+         git_log_json = json.loads(cmd_log(cmd, cwd=rdirp))
+         commit_id = git_log_json['commit']
     except subprocess.CalledProcessError as ex:
         log.exception('Unable to get git log: %r', ex.output)
         raise GitImportErrorBadRepo()
@@ -321,26 +342,23 @@ def add_repo(repo, rdir_in, branch=None):
             log.debug(subprocess.check_output(['ls', '-l', ],
                                               cwd=os.path.abspath(cdir)))
 
-    # store import-command-run output in mongo
-    mongouri = 'mongodb://{user}:{password}@{host}:{port}/{db}'.format(**mongo_db)
+    mdb = open_mongo_connection()
+    if mdb is not None:
+        cil = CourseImportLog(
+            course_id=course_key,
+            location=location,
+            repo_dir=rdir,
+            created=timezone.now(),
+            import_log=ret_import,
+            author=git_log_json['author'],
+            commit=git_log_json['commit'],
+            date=parser.parse(git_log_json['date']),
+            git_log=ret_git,
+        )
+        cil.save()
 
-    try:
-        if mongo_db['user'] and mongo_db['password']:
-            mdb = mongoengine.connect(mongo_db['db'], host=mongouri)
-        else:
-            mdb = mongoengine.connect(mongo_db['db'], host=mongo_db['host'], port=mongo_db['port'])
-    except mongoengine.connection.ConnectionError:
-        log.exception('Unable to connect to mongodb to save log, please '
-                      'check MONGODB_LOG settings')
-    cil = CourseImportLog(
-        course_id=course_key,
-        location=location,
-        repo_dir=rdir,
-        created=timezone.now(),
-        import_log=ret_import,
-        git_log=ret_git,
-    )
-    cil.save()
+        log.debug('saved CourseImportLog for %s', cil.course_id)
+        mdb.disconnect()
+    else:
+        log.error('Unable to save CourseImportLog because of an error in building mongo connection')
 
-    log.debug('saved CourseImportLog for %s', cil.course_id)
-    mdb.disconnect()

--- a/lms/djangoapps/dashboard/models.py
+++ b/lms/djangoapps/dashboard/models.py
@@ -12,7 +12,10 @@ class CourseImportLog(mongoengine.Document):
     location = mongoengine.StringField(max_length=168)
     import_log = mongoengine.StringField(max_length=20 * 65535)
     git_log = mongoengine.StringField(max_length=65535)
-    repo_dir = mongoengine.StringField(max_length=128)
+    repo_dir = mongoengine.StringField(max_length=128, null=True)
+    commit = mongoengine.StringField(max_length=40, null=True)
+    author = mongoengine.StringField(max_length=500, null=True)
+    date = mongoengine.DateTimeField()
     created = mongoengine.DateTimeField()
     meta = {'indexes': ['course_id', 'created'],
             'allow_inheritance': False}

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -356,7 +356,7 @@ class Courses(SysadminDashboardView):
                 info[1] = logs[1]
                 info[2] = logs[2]
             else:
-                # if course do not have git commit hash the import and cach.
+                # if a course do not have git commit hash then fetch from git and cache.
                 cmd = ''
                 gdir = settings.DATA_DIR / cdir
 

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -2,6 +2,7 @@
 This module creates a sysadmin dashboard for managing and viewing
 courses.
 """
+from dateutil import parser
 import unicodecsv as csv
 import json
 import logging
@@ -335,30 +336,56 @@ class Courses(SysadminDashboardView):
     provides course listing information.
     """
 
-    def git_info_for_course(self, cdir):
+    def git_info_for_course(self, cdir, course_id):
         """This pulls out some git info like the last commit"""
-
-        cmd = ''
-        gdir = settings.DATA_DIR / cdir
         info = ['', '', '']
+        # only if course has git import history
+        if CourseImportLog.objects.filter(course_id=course_id).count() > 0:
+            # check if course has git commit hash
+            logs = CourseImportLog.objects.filter(
+                course_id=course_id,
+                commit__ne=None
+            ).values_list(
+                'commit',
+                'date',
+                'author'
+            ).order_by('-created').first()
 
-        # Try the data dir, then try to find it in the git import dir
-        if not gdir.exists():
-            git_repo_dir = getattr(settings, 'GIT_REPO_DIR', git_import.DEFAULT_GIT_REPO_DIR)
-            gdir = path(git_repo_dir) / cdir
-            if not gdir.exists():
-                return info
+            if logs:
+                info[0] = logs[0]
+                info[1] = logs[1]
+                info[2] = logs[2]
+            else:
+                # if course do not have git commit hash the import and cach.
+                cmd = ''
+                gdir = settings.DATA_DIR / cdir
 
-        cmd = ['git', 'log', '-1',
-               '--format=format:{ "commit": "%H", "author": "%an %ae", "date": "%ad"}', ]
-        try:
-            output_json = json.loads(subprocess.check_output(cmd, cwd=gdir))
-            info = [output_json['commit'],
-                    output_json['date'],
-                    output_json['author'], ]
-        except (ValueError, subprocess.CalledProcessError):
-            pass
+                # Try the data dir, then try to find it in the git import dir
+                if not gdir.exists():
+                    git_repo_dir = getattr(settings, 'GIT_REPO_DIR', git_import.DEFAULT_GIT_REPO_DIR)
+                    gdir = path(git_repo_dir) / cdir
+                    if not gdir.exists():
+                        return info
 
+                cmd = ['git', 'log', '-1',
+                       '--format=format:{ "commit": "%H", "author": "%an %ae", "date": "%ad"}', ]
+                try:
+                    output_json = json.loads(subprocess.check_output(cmd, cwd=gdir))
+                    info = [output_json['commit'],
+                            output_json['date'],
+                            output_json['author'], ]
+
+                    # cache the git log info
+                    course = CourseImportLog.objects.filter(
+                        course_id=course_id,
+                    ).order_by('-created').first()
+                    course.author = output_json['author']
+                    course.commit = output_json['commit']
+                    course.date = parser.parse(output_json['date'])
+                    course.save()
+                    log.debug('Updated git logs for course %s', course_id)
+                except (ValueError, subprocess.CalledProcessError):
+                    pass
         return info
 
     def get_course_from_git(self, gitloc, branch):
@@ -423,22 +450,25 @@ class Courses(SysadminDashboardView):
 
     def make_datatable(self):
         """Creates course information datatable"""
-
         data = []
+        mdb = git_import.open_mongo_connection()
+        if mdb is not None:
+            for course in self.get_courses():
+                gdir = course.id.course
+                data.append([course.display_name, text_type(course.id)]
+                            + self.git_info_for_course(gdir, course.id))
 
-        for course in self.get_courses():
-            gdir = course.id.course
-            data.append([course.display_name, text_type(course.id)]
-                        + self.git_info_for_course(gdir))
-
-        return dict(header=[_('Course Name'),
-                            _('Directory/ID'),
-                            # Translators: "Git Commit" is a computer command; see http://gitref.org/basic/#commit
-                            _('Git Commit'),
-                            _('Last Change'),
-                            _('Last Editor')],
-                    title=_('Information about all courses'),
-                    data=data)
+            mdb.disconnect()
+            return dict(header=[_('Course Name'),
+                                _('Directory/ID'),
+                                # Translators: "Git Commit" is a computer command; see http://gitref.org/basic/#commit
+                                _('Git Commit'),
+                                _('Last Change'),
+                                _('Last Editor')],
+                        title=_('Information about all courses'),
+                        data=data)
+        else:
+            log.error('Unable to save CourseImportLog because of an error in building mongo connection')
 
     def get(self, request):
         """Displays forms and course information"""
@@ -588,34 +618,9 @@ class GitLogs(TemplateView):
             course_id = CourseKey.from_string(course_id)
 
         page_size = 10
-
-        # Set mongodb defaults even if it isn't defined in settings
-        mongo_db = {
-            'host': 'localhost',
-            'user': '',
-            'password': '',
-            'db': 'xlog',
-        }
-
-        # Allow overrides
-        if hasattr(settings, 'MONGODB_LOG'):
-            for config_item in ['host', 'user', 'password', 'db', ]:
-                mongo_db[config_item] = settings.MONGODB_LOG.get(
-                    config_item, mongo_db[config_item])
-
-        mongouri = 'mongodb://{user}:{password}@{host}/{db}'.format(**mongo_db)
-
         error_msg = ''
 
-        try:
-            if mongo_db['user'] and mongo_db['password']:
-                mdb = mongoengine.connect(mongo_db['db'], host=mongouri)
-            else:
-                mdb = mongoengine.connect(mongo_db['db'], host=mongo_db['host'])
-        except mongoengine.connection.ConnectionError:
-            log.exception('Unable to connect to mongodb to save log, '
-                          'please check MONGODB_LOG settings.')
-
+        mdb = git_import.open_mongo_connection()
         if course_id is None:
             # Require staff if not going to specific course
             if not request.user.is_staff:


### PR DESCRIPTION
#### Pre req:
insert columns in mongo table `xlog`.
```shell:
vagrant ssh
mongo
use xlog
db.course_import_log.update({}, {$set: {"commit": null, "author": null, "date": null}}, false, true)
```

### What are the relevant tickets?
fixes https://github.com/mitodl/edx-platform/issues/44

#### What's this PR do?
- it add git-logs i.e author, commit hash and date to `CourseImportLog` model.
- it check if course has git-log history only then load git-logs info
- it check if git-logs  info is not available the download and same in `CourseImportLog` 
- In sum it enhances performance of courses page in system admin.
- It makes `courses` load 3 sec faster then courses on `mitx/ginkgo` branch

#### How should this be manually tested?
- Go to system admin as staff.
- load page first time and see the time span.
- load for 2nd time and so on it will cache and decrease the time span

@pdpinch 

#### Screenshot:
##### Localhost (this `enhance` branch):
<img width="714" alt="screen shot 2018-05-22 at 4 44 11 pm" src="https://user-images.githubusercontent.com/10431250/40360361-67de70ea-5ddf-11e8-9dd8-f66a92cc67a0.png">

<img width="1235" alt="screen shot 2018-05-22 at 4 48 33 pm" src="https://user-images.githubusercontent.com/10431250/40360571-04371fa0-5de0-11e8-8e98-109e61ee58ec.png">

##### mitx-qa.mitx.mit.edu (`mitx/ginkgo` branch):
<img width="915" alt="screen shot 2018-05-22 at 4 40 19 pm" src="https://user-images.githubusercontent.com/10431250/40360256-fddfa4c0-5dde-11e8-83ed-5530c53e2bd2.png">

<img width="649" alt="screen shot 2018-05-22 at 4 49 18 pm" src="https://user-images.githubusercontent.com/10431250/40360598-1aa51c92-5de0-11e8-8243-fec09b15c668.png">


