### PR TITLE
Redirect new user to login page on courses

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -3,6 +3,7 @@ import logging
 import urllib
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -77,6 +78,7 @@ def index(request):
     return student.views.index(request, user=request.user)
 
 
+@login_required
 @ensure_csrf_cookie
 @cache_if_anonymous()
 def courses(request):


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/598

#### What's this PR do
it redirect user to to login page, if he has not logged into system. Otherwise display list of courses

#### How should this be manually tested?
- Try to open http://localhost:8000/courses without login
- Try to open http://localhost:8000/courses with login

cc @pdpinch 

#### Screenshots (if appropriate)
<img width="1262" alt="screen shot 2018-05-30 at 4 26 48 pm" src="https://user-images.githubusercontent.com/10431250/40717589-55052d72-6426-11e8-8fa3-ba2081d8e4f1.png">

<img width="1259" alt="screen shot 2018-05-30 at 4 27 08 pm" src="https://user-images.githubusercontent.com/10431250/40717590-55346d94-6426-11e8-80c2-a4f8babc6c52.png">
