### PR TITLE
Redirect user to CAS instead of edX registration page

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -206,6 +206,10 @@ def register_user(request, extra_context=None):
     if request.user.is_authenticated():
         return redirect(redirect_to)
 
+    if settings.FEATURES.get('AUTH_USE_CAS'):
+        # If CAS is enabled, redirect auth handling to there
+        return redirect(reverse('cas-login'))
+
     external_auth_response = external_auth_register(request)
     if external_auth_response is not None:
         return external_auth_response


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/562

#### What's this PR do?
It redirects user to mit CAS login page instead of edX registration page, check the issue to reproduce it

#### How should this be manually tested?
- Logout edX
- open about page of a course https://lms.mitx.mit.edu/courses/(🆔)/about
- click enroll
- it will take you to CAS login process 

@pdpinch 