### PR TITLE
Added 'date_joined' to list of fields checked for auto enrollment

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -556,7 +556,7 @@ def user_post_save_callback(sender, **kwargs):
 
     changed_fields = user._changed_fields
 
-    if 'is_active' in changed_fields or 'email' in changed_fields:
+    if 'is_active' in changed_fields or 'email' in changed_fields or 'date_joined' in changed_fields:
         if user.is_active:
             ceas = CourseEnrollmentAllowed.for_user(user).filter(auto_enroll=True)
 


### PR DESCRIPTION
Because CAS creates the user with `is_active` and `email` already set there is no change in those fields. By adding `date_joined` to the list of fields checked the auto enrollment will be processed properly.