### PR TITLE
Fixed transcript export to git

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -18,6 +18,7 @@ import logging
 import random
 from collections import defaultdict, OrderedDict
 from operator import itemgetter
+from fs.path import combine
 
 from pkg_resources import resource_string
 
@@ -725,7 +726,13 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         if edxval_api and edx_video_id:
             try:
                 # Create static dir if not created earlier.
-                resource_fs.makedirs(EXPORT_IMPORT_STATIC_DIR, recreate=True)
+                resource_fs.makedirs(
+                    combine(
+                        EXPORT_IMPORT_COURSE_DIR,
+                        EXPORT_IMPORT_STATIC_DIR
+                    ),
+                    recreate=True
+                )
 
                 xml.append(
                     edxval_api.export_to_xml(


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/edx-platform/issues/104

#### What's this PR do?
Fixes issue which appears when directories for transcript export are missing

#### How should this be manually tested?
- Test export to git
- Test export to file system

### Any background context you want to provide?
- Issue appear when edx-val app expects **course** folder inside export_import directory. This is a temporary folder used by video module to copy transcript before exporting. I created course folder and it works


@pdpinch 
