### PR TITLE
Download reports from instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -90,4 +90,8 @@ urlpatterns = [
     url(r'^generate_bulk_certificate_exceptions', api.generate_bulk_certificate_exceptions,
         name='generate_bulk_certificate_exceptions'),
     url(r'^certificate_invalidation_view/$', api.certificate_invalidation_view, name='certificate_invalidation_view'),
+
+    # rapid response downloads
+    url(r'rapid_response_report/(?P<run_id>[^/]*)$', api.get_rapid_response_report,
+        name='get_rapid_response_report'),
 ]

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -16,6 +16,8 @@ from courseware.field_overrides import disable_overrides
 from courseware.models import StudentFieldOverride
 from courseware.student_field_overrides import clear_override_for_user, get_override_for_user, override_field_for_user
 from xmodule.fields import Date
+from xmodule.modulestore.django import modulestore
+
 
 DATE_FIELD = Date()
 
@@ -242,3 +244,8 @@ def add_block_ids(payload):
         for ele in payload['data']:
             if 'module_id' in ele:
                 ele['block_id'] = UsageKey.from_string(ele['module_id']).block_id
+
+
+def get_display_name_from_usage_key(key):
+    """Return problem display name from given UsageKey."""
+    return modulestore().get_item(key).display_name

--- a/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
+++ b/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
@@ -1,0 +1,28 @@
+<%page args="section_data" expression_filter="h"/>
+<%!
+from itertools import groupby
+
+from django.utils.translation import ugettext as _
+from django.urls import reverse
+
+from instructor.views.tools import get_display_name_from_usage_key
+%>
+
+
+<div>
+    % for date,runs in groupby(section_data['problem_runs'],key=lambda x:x['created'].date()):
+    <ul>
+        <li>${date.strftime('%Y/%m/%d')}</li>
+        <ul>
+            % for run in runs:
+            <li>${get_display_name_from_usage_key(run['problem_usage_key'])} - ${run['created'].strftime('%I:%M:%S %p')}:
+                <a type="button" class="btn-link"
+                   href="${reverse('get_rapid_response_report', kwargs={'course_id': section_data['course_key'], 'run_id': run['id']})}">
+                    ${_("Download")}
+                </a>
+            </li>
+            % endfor
+        </ul>
+    </ul>
+    % endfor
+</div>


### PR DESCRIPTION
Fixes [#71 ](https://github.com/mitodl/rapid-response-xblock/issues/71)

I can see there no field `name` available in model [RapidResponseRun]( https://github.com/mitodl/rapid-response-xblock/blob/master/rapid_response_xblock/models.py#L18-L42). However I can see it in mysql table

<img width="713" alt="screen shot 2018-12-04 at 4 28 40 pm" src="https://user-images.githubusercontent.com/4245618/49439037-d0f1a600-f7e1-11e8-8b53-639630c71639.png">


Why is this discrepancy in model ?

Also I have added some code (ignore quality and testing) for adding new tab in **instructor board.** 

<img width="1007" alt="screen shot 2018-12-04 at 4 21 59 pm" src="https://user-images.githubusercontent.com/4245618/49439115-06968f00-f7e2-11e8-908d-e71eb8b21004.png">

**Downloaded CSV** 
[rapid_reponses_submissions (13).csv.zip](https://github.com/mitodl/edx-platform/files/2644325/rapid_reponses_submissions.13.csv.zip)

@pdpinch , @gsidebo @noisecapella  It would be great if I can get some initial review on this, just to make sure that I am going in right direction. 
