### PR TITLE
Issue 119 : Rapid response report crashes instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -17,6 +17,7 @@ from courseware.models import StudentFieldOverride
 from courseware.student_field_overrides import clear_override_for_user, get_override_for_user, override_field_for_user
 from xmodule.fields import Date
 from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
 
 
 DATE_FIELD = Date()
@@ -247,5 +248,16 @@ def add_block_ids(payload):
 
 
 def get_display_name_from_usage_key(key):
-    """Return problem display name from given UsageKey."""
-    return modulestore().get_item(key).display_name
+    """
+    Returns problem display name from given block UsageKey.
+
+    Args:
+        key (UsageKey) : Usage key of block
+
+    Returns:
+        String : Returns the display name of block if exists else 'Deleted'.
+    """
+    try:
+        return modulestore().get_item(key).display_name
+    except ItemNotFoundError:
+        return "Deleted"


### PR DESCRIPTION
This pr handles the edge case in which instructor dashboard crashes if a rapid response block was deleted. Following are the steps to reproduce the issue. 
1. In studio, add Rapid Response to a problem
2. In lms, open the problem and close it (no need to generate any student data)
3. Back in studio, delete the problem. 
4. Back in lms, open the Instructor dashboard

Screenshot of Solution: 
![screenshot from 2019-01-04 15-51-06](https://user-images.githubusercontent.com/7721119/50685001-667a9280-1039-11e9-815e-b945c5bd1e31.png)

