### PR TITLE
Issue-119

### DIFF
--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -246,6 +246,19 @@ def add_block_ids(payload):
                 ele['block_id'] = UsageKey.from_string(ele['module_id']).block_id
 
 
+def check_valid_usage_key(key):
+    """
+    Checks if block exists for UsageKey.
+
+    Args:
+        key (UsageKey) : Usage key of a block
+
+    Returns:
+        Boolean: True if key exists or false
+    """
+    return modulestore().has_item(key)
+
+
 def get_display_name_from_usage_key(key):
     """Return problem display name from given UsageKey."""
     return modulestore().get_item(key).display_name

--- a/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
+++ b/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
@@ -5,7 +5,7 @@ from itertools import groupby
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 
-from instructor.views.tools import get_display_name_from_usage_key
+from instructor.views.tools import check_valid_usage_key, get_display_name_from_usage_key
 %>
 
 
@@ -15,13 +15,15 @@ from instructor.views.tools import get_display_name_from_usage_key
         <li>${date.strftime('%Y/%m/%d')}</li>
         <ul>
             % for run in runs:
-            <li>${get_display_name_from_usage_key(run['problem_usage_key'])} - ${run['created'].strftime('%I:%M:%S %p')}:
-                <a type="button" class="btn-link"
-                   href="${reverse('get_rapid_response_report', kwargs={'course_id': section_data['course_key'], 'run_id': run['id']})}">
-                    ${_("Download")}
-                </a>
-            </li>
-            % endfor
+                % if check_valid_usage_key(run['problem_usage_key']):
+                    <li>${get_display_name_from_usage_key(run['problem_usage_key'])} - ${run['created'].strftime('%I:%M:%S %p')}:
+                        <a type="button" class="btn-link"
+                           href="${reverse('get_rapid_response_report', kwargs={'course_id': section_data['course_key'], 'run_id': run['id']})}">
+                            ${_("Download")}
+                        </a>
+                    </li>
+                % endif
+            %endfor
         </ul>
     </ul>
     % endfor


### PR DESCRIPTION
This pr handles the edge case in which instructor dashboard crashes if a rapid response block was deleted. Following are the steps to reproduce the issue.

In studio, add Rapid Response to a problem
In lms, open the problem and close it (no need to generate any student data)
Back in studio, delete the problem.
Back in lms, open the Instructor dashboard

Screenshot of Solution:
![screenshot from 2019-01-04 18-14-07](https://user-images.githubusercontent.com/7721119/50689708-95e6ca80-104c-11e9-8832-9647a8661d29.png)
