### PR TITLE
Updated to pull the whole course structure at once

### DIFF
--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -247,7 +247,7 @@ def add_block_ids(payload):
                 ele['block_id'] = UsageKey.from_string(ele['module_id']).block_id
 
 
-def get_display_name_from_usage_key(key):
+def get_display_name_from_usage_key(key, course):
     """
     Returns problem display name from given block UsageKey.
 
@@ -257,7 +257,4 @@ def get_display_name_from_usage_key(key):
     Returns:
         String : Returns the display name of block if exists else 'Deleted'.
     """
-    try:
-        return modulestore().get_item(key).display_name
-    except ItemNotFoundError:
-        return "Deleted"
+    return course.get_child(key).display_name

--- a/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
+++ b/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
@@ -5,17 +5,19 @@ from itertools import groupby
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 
+from courseware.courses import get_course_by_id
 from instructor.views.tools import get_display_name_from_usage_key
 %>
 
 
 <div>
+    <% course = get_course_by_id(section_data['course_key'], depth=None) %>
     % for date,runs in groupby(section_data['problem_runs'],key=lambda x:x['created'].date()):
     <ul>
         <li>${date.strftime('%Y/%m/%d')}</li>
         <ul>
             % for run in runs:
-            <li>${get_display_name_from_usage_key(run['problem_usage_key'])} - ${run['created'].strftime('%I:%M:%S %p')}:
+            <li>${get_display_name_from_usage_key(run['problem_usage_key'], course)} - ${run['created'].strftime('%I:%M:%S %p')}:
                 <a type="button" class="btn-link"
                    href="${reverse('get_rapid_response_report', kwargs={'course_id': section_data['course_key'], 'run_id': run['id']})}">
                     ${_("Download")}


### PR DESCRIPTION
The rapid response view was causing the instructor dashboard to time out with a large number of Rapid Reponse runs. This is because it was making a call to Mongo for each run, even if it was for a block that was already retrieved. This patch loads the whole course structure and then retrieves the block names from the in memory object, rather than making additional network calls.