### PR TITLE
Updated Pillow version to resolve error

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -184,7 +184,7 @@ paver==1.3.4
 pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
-pillow==5.4.1
+pillow==6.1.0
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py2neo==3.1.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -233,7 +233,7 @@ paver==1.3.4
 pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
-pillow==5.4.1
+pillow==6.1.0
 pip-tools==3.2.0
 pluggy==0.8.1
 polib==1.1.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -224,7 +224,7 @@ paver==1.3.4
 pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
-pillow==5.4.1
+pillow==6.1.0
 pluggy==0.8.1             # via pytest, tox
 polib==1.1.0
 psutil==1.2.1


### PR DESCRIPTION
Old version of Pillow is throwing the following error:
```
AttributeError: 'PngStream' object has no attribute 'chunk_tIME'
```

Based on this [issue](https://github.com/python-pillow/Pillow/issues/3557) new version should resolve this problem.