### PR TITLE
#1018 Remove "Enroll Now" button fixes mitodl/mitxpro#1018

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -352,7 +352,7 @@ def course_info(request, course_id):
         # LEARNER-1697: Transition banner messages to new Course Home (DONE)
         # if user is not enrolled in a course then app will show enroll/get register link inside course info page.
         user_is_enrolled = CourseEnrollment.is_enrolled(user, course.id)
-        show_enroll_banner = request.user.is_authenticated and not user_is_enrolled
+        show_enroll_banner = request.user.is_authenticated and not user_is_enrolled and not course.invitation_only
 
         # If the user is not enrolled but this is a course that does not support
         # direct enrollment then redirect them to the dashboard.
@@ -554,7 +554,7 @@ class CourseTabView(EdxFragmentView):
                 )
             )
         else:
-            if not CourseEnrollment.is_enrolled(request.user, course.id) and not allow_anonymous:
+            if not CourseEnrollment.is_enrolled(request.user, course.id) and not allow_anonymous and not course.invitation_only:
                 # Only show enroll button if course is open for enrollment.
                 if course_open_for_self_enrollment(course.id):
                     enroll_message = _(u'You must be enrolled in the course to see course content. \

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -149,6 +149,10 @@ from six import string_types
         ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
         ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click
         ## so that they can register and become a real user that can enroll.
+        % elif not is_shib_course and invitation_only:
+          <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
+        ## Non-shib courses respect the value of invitation_only and so do not show the enroll button
+        ## if the course is set to invitation only
         % elif not is_shib_course and not can_enroll:
           <span class="register disabled">${_("Enrollment is Closed")}</span>
         %elif can_add_course_to_cart:

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -5,6 +5,7 @@ View logic for handling course messages.
 from datetime import datetime
 
 from babel.dates import format_date, format_timedelta
+from django.conf import settings
 from django.contrib import auth
 from django.template.loader import render_to_string
 from django.utils.http import urlquote_plus
@@ -125,18 +126,32 @@ def _register_course_home_messages(request, course, user_access, course_start_da
             title=Text(_('You must be enrolled in the course to see course content.'))
         )
     if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
-        CourseHomeMessages.register_info_message(
-            request,
-            Text(_(
-                '{open_enroll_link}Enroll now{close_enroll_link} to access the full course.'
-            )).format(
-                open_enroll_link=HTML('<button class="enroll-btn btn-link">'),
-                close_enroll_link=HTML('</button>')
-            ),
-            title=Text(_('Welcome to {course_display_name}')).format(
-                course_display_name=course.display_name
+        if not course.invitation_only:
+            CourseHomeMessages.register_info_message(
+                request,
+                Text(_(
+                    '{open_enroll_link}Enroll now{close_enroll_link} to access the full course.'
+                )).format(
+                    open_enroll_link=HTML('<button class="enroll-btn btn-link">'),
+                    close_enroll_link=HTML('</button>')
+                ),
+                title=Text(_('Welcome to {course_display_name}')).format(
+                    course_display_name=course.display_name
+                )
             )
-        )
+        else:
+            CourseHomeMessages.register_info_message(
+                request,
+                Text(_(
+                    '{open_register_disabled}Enrollment in this course is by invitation only{close_register_disabled}'
+                )).format(
+                    open_register_disabled=HTML('<span class="register disabled">'),
+                    close_register_disabled=HTML('</span>')
+                ),
+                title=Text(_('Welcome to {course_display_name}')).format(
+                    course_display_name=course.display_name
+                )
+            )
 
 
 def _register_course_goal_message(request, course):


### PR DESCRIPTION
~~This PR removes the "Enroll Now" link/button from the LMS UI.~~

~~This PR adds a feature setting `COURSE_DEFAULT_INVITE_ONLY` that disables/removes "Enroll Now" buttons on the UI. The default value is `False` and can be changed from the environment.~~

Updates the templates to respect `course.invitation_only` and show the correct message where applicable (and remove the "Enroll Now" button as well).

### How to test this
Create a course and set `course.invitation_only` to `True`. Visit the course page directly, it should not show any button to enroll yourself (typically labelled "Enroll Now").

~~Screenshot is highlighted where the button/link was removed.~~
### Screenshot
Course About
![Screenshot from 2019-09-18 18-02-03](https://user-images.githubusercontent.com/45350418/65153040-85437c80-da42-11e9-9350-76c6087bace9.png)

Course Home
![Screenshot from 2019-09-18 18-27-11](https://user-images.githubusercontent.com/45350418/65153050-8aa0c700-da42-11e9-9779-bf39ad613c8f.png)
