### PR TITLE
asadiqbal08/mitxpro-150  Individual Due Date does not display in course outline 

### DIFF
--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -1,11 +1,16 @@
 """
 Serializers for Course Blocks related return objects.
 """
+import json
 from django.conf import settings
+from lms.djangoapps.courseware.models import StudentFieldOverride
+from xmodule.fields import Date
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
 from .transformers import SUPPORTED_FIELDS
+
+DATE_FIELD = Date()
 
 
 class BlockSerializer(serializers.Serializer):  # pylint: disable=abstract-method
@@ -67,6 +72,21 @@ class BlockSerializer(serializers.Serializer):  # pylint: disable=abstract-metho
                     supported_field.default_value,
                 )
                 if field_value is not None:
+                    # override due date with student extension in unit added by instructor.
+                    if supported_field.block_field_name == 'due':
+                        value = None
+                        override = StudentFieldOverride.objects.filter(
+                            course_id=block_key.course_key,
+                            student=self.context['request'].user,
+                            location=block_key,
+                            field='due'
+                        ).first()
+                        if override and override.value:
+                            value = DATE_FIELD.from_json(json.loads(override.value))
+
+                        if value:
+                            field_value = value
+
                     # only return fields that have data
                     data[supported_field.serializer_field_name] = field_value
 

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -1,15 +1,20 @@
 """
 Tests for Course Blocks serializers
 """
-from mock import MagicMock
-
+from courseware.tests.factories import InstructorFactory
+import datetime
+from django.test import RequestFactory
+from django.urls import reverse
 from lms.djangoapps.course_blocks.api import get_course_block_access_transformers, get_course_blocks
+from mock import MagicMock
 from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers
+from pytz import UTC
+from six import text_type
 from student.roles import CourseStaffRole
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import ToyCourseFactory
+from xmodule.modulestore.tests.factories import ToyCourseFactory, CourseFactory, ItemFactory
 
 from ..serializers import BlockDictSerializer, BlockSerializer
 from ..transformers.blocks_api import BlocksAPITransformer
@@ -51,8 +56,10 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
             self.course.location,
             self.transformers,
         )
+        self.request = RequestFactory().request()
+        self.request.user = self.user
         self.serializer_context = {
-            'request': MagicMock(),
+            'request': self.request,
             'block_structure': self.block_structure,
             'requested_fields': ['type'],
         }
@@ -86,6 +93,7 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
             'student_view_data',
             'student_view_multi_device',
             'lti_url',
+            'due',
             'visible_to_staff_only',
         ])
 
@@ -237,3 +245,68 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
             self.assert_extended_block(serialized_block)
             self.assert_staff_fields(serialized_block)
         self.assertEquals(len(serializer.data['blocks']), 29)
+
+
+class TestDueDateExtensionsSerializer(TestBlockSerializerBase):
+    """
+    Test data dumps for reporting.
+    """
+    def create_serializer(self, context=None):
+        """
+        creates a BlockSerializer
+        """
+        if context is None:
+            context = self.serializer_context
+        return BlockSerializer(
+            context['block_structure'], many=True, context=context,
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestDueDateExtensionsSerializer, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.due = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=UTC)
+        cls.user = UserFactory.create()
+        with cls.store.bulk_operations(cls.course.id, emit_signals=False):
+            cls.week1 = ItemFactory.create(
+                due=cls.due,
+                category='chapter',
+                display_name='test_chapter_with_due_date',
+            )
+            cls.week2 = ItemFactory.create()  # No due date
+            cls.course.children = [
+                text_type(cls.week1.location),
+                text_type(cls.week2.location),
+            ]
+            cls.homework = ItemFactory.create(
+                parent_location=cls.week1.location,
+                category='sequential',
+                display_name='test chapter sequence'
+            )
+            cls.week1.children = [text_type(cls.homework.location)]
+
+    def test_date_extension(self):
+        """
+        Test fields accessed by a staff user
+        """
+        self.instructor = InstructorFactory(course_key=self.course.id)
+        self.client.login(username=self.instructor.username, password='test')
+        url = reverse('change_due_date', kwargs={'course_id': text_type(self.course.id)})
+        response = self.client.post(url, {
+            'student': self.user.username,
+            'url': text_type(self.week1.location),
+            'due_datetime': '12/30/2040 00:00'
+        })
+
+        self.assertEqual(response.status_code, 200, response.content)
+
+        self.add_additional_requested_fields()
+        serializer = self.create_serializer()
+        for serialized_block in serializer.data:
+            if serialized_block['type'] == 'chapter':
+                if serialized_block['display_name'] == 'test_chapter_with_due_date':
+                    self.assertTrue(
+                        serialized_block['due'] == datetime.datetime(2040, 12, 30, 0, 0, tzinfo=UTC)
+                    )
+
+        self.assertEquals(len(serializer.data), 4)


### PR DESCRIPTION
Task: #150 

**How to Test**
- Make sure flag should be turn on `INDIVIDUAL_DUE_DATES`
- After the above flag is turned on, make sure `FIELD_OVERRIDE_PROVIDERS` also set properly.
```
    FIELD_OVERRIDE_PROVIDERS += (
        'lms.djangoapps.courseware.student_field_overrides.IndividualStudentOverrideProvider',
    ) 
     --- > Ref: aws.py

```
- First, I set a due date for a unit in studio like that. 
<img width="1254" alt="Screen Shot 2019-11-22 at 6 34 13 PM" src="https://user-images.githubusercontent.com/7334669/69522753-00199e00-0f84-11ea-888b-3f99048b35f0.png">

- Now it is appearing like that over LMS course overview
<img width="876" alt="Screen Shot 2019-11-22 at 6 33 17 PM" src="https://user-images.githubusercontent.com/7334669/69522775-10317d80-0f84-11ea-8ca0-9f7f2ce99049.png">

- Give an extension in date for a student via instructor dashboard.
<img width="1227" alt="Screen Shot 2019-11-22 at 6 33 39 PM" src="https://user-images.githubusercontent.com/7334669/69522794-1f183000-0f84-11ea-8eb5-75714a97ed0c.png">

- Course detail should render the extended date (individual user level) as we set via instructor panel, simply this screen will show a new extended date for the particular user only .
<img width="876" alt="Screen Shot 2019-11-22 at 6 33 17 PM" src="https://user-images.githubusercontent.com/7334669/69522880-57b80980-0f84-11ea-9523-89834657f5c2.png">

