### PR TITLE
Restricting login to only third party auth

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -34,6 +34,7 @@ from openedx.core.djangoapps.user_api.serializers import CountryTimeZoneSerializ
 from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.views.register import create_account_with_params
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
+from third_party_auth import pipeline
 from student.helpers import AccountValidationError
 from util.json_request import JsonResponse
 
@@ -122,6 +123,11 @@ class RegistrationView(APIView):
                 address already exists
             HttpResponse: 403 operation not allowed
         """
+
+        if not pipeline.running(request):
+            # if request is not running a third-party auth pipeline
+            return HttpResponseForbidden("Not allowed to register")
+
         data = request.POST.copy()
 
         email = data.get('email')

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -11,7 +11,7 @@ from django.contrib.auth import authenticate, login as django_login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.urls import reverse
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
@@ -327,6 +327,8 @@ def login_user(request):
     first_party_auth_requested = bool(request.POST.get('email')) or bool(request.POST.get('password'))
     is_user_third_party_authenticated = False
 
+    if not third_party_auth_requested:
+        return HttpResponseForbidden("First party login not supported")
     try:
         if third_party_auth_requested and not first_party_auth_requested:
             # The user has already authenticated via third-party auth and has not


### PR DESCRIPTION
Task #148 

Restrict user login and registration to only third party authentication backend, restrict public account creation.

