### PR TITLE
Added extra arguments for proctoring and enable instructor service for cms.

### DIFF
--- a/lms/djangoapps/grades/services.py
+++ b/lms/djangoapps/grades/services.py
@@ -56,7 +56,7 @@ class GradesService(object):
         return PersistentSubsectionGradeOverride.get_override(user_id, usage_key)
 
     def override_subsection_grade(self, user_id, course_key_or_id, usage_key_or_id, earned_all=None,
-                                  earned_graded=None):
+                                  earned_graded=None, overrider=None, comment=None):
         """
         Override subsection grade (the PersistentSubsectionGrade model must already exist)
 

--- a/openedx/core/djangoapps/credit/apps.py
+++ b/openedx/core/djangoapps/credit/apps.py
@@ -17,4 +17,6 @@ class CreditConfig(AppConfig):
         from . import signals
         if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
             from .services import CreditService
+            from lms.djangoapps.instructor.services import InstructorService
             set_runtime_service('credit', CreditService())
+            set_runtime_service('instructor', InstructorService())


### PR DESCRIPTION
Changes to make edx-proctoring 2.2.4 work with proctortrack in ironwood.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
