### PR TITLE
Removing edx-proctoring requirement in favor of our fork

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -80,7 +80,6 @@ edx-enterprise
 edx-milestones
 edx-oauth2-provider
 edx-organizations
-edx-proctoring>=1.5.3
 edx-proctoring-proctortrack
 edx-rest-api-client
 edx-search

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -125,7 +125,6 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.0
 edx-proctoring-proctortrack==1.0.1
-edx-proctoring==1.5.7
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-submissions==2.0.12


### PR DESCRIPTION
Removing the edx-proctoring dependenc and replacing the requirement via Ansible through salt-ops
