### PR TITLE
Use OVERRIDE_GRADES permission instead of is_staff

### DIFF
--- a/lms/djangoapps/canvas_integration/views.py
+++ b/lms/djangoapps/canvas_integration/views.py
@@ -1,6 +1,4 @@
-from bridgekeeper.rules import is_staff
 from django.contrib.auth.models import User
-from django.http import HttpResponse
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
@@ -9,7 +7,8 @@ from opaque_keys.edx.locator import CourseLocator
 from canvas_integration.client import CanvasClient
 from courseware.courses import get_course_by_id
 from canvas_integration import api
-from remote_gradebook.api import require_course_permission
+from lms.djangoapps.instructor.views.api import require_course_permission
+from lms.djangoapps.instructor import permissions
 from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from util.json_request import JsonResponse
 
@@ -28,7 +27,7 @@ def _get_edx_enrollment_data(email, course_key):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def list_canvas_enrollments(request, course_id):
     """
     Fetch enrollees for a course in canvas and list them
@@ -52,7 +51,7 @@ def list_canvas_enrollments(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def add_canvas_enrollments(request, course_id):
     """
     Fetches enrollees for a course in canvas and enrolls those emails in the course in edX
@@ -73,7 +72,7 @@ def add_canvas_enrollments(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def list_canvas_assignments(request, course_id):
     """List Canvas assignments"""
     course_key = CourseLocator.from_string(course_id)
@@ -87,7 +86,7 @@ def list_canvas_assignments(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def list_canvas_grades(request, course_id):
     """List grades"""
     assignment_id = int(request.GET.get("assignment_id"))
@@ -102,7 +101,7 @@ def list_canvas_grades(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def push_edx_grades(request, course_id):
     """Push user grades for all graded items in edX to Canvas"""
     course_key = CourseLocator.from_string(course_id)

--- a/lms/djangoapps/canvas_integration/views.py
+++ b/lms/djangoapps/canvas_integration/views.py
@@ -27,7 +27,7 @@ def _get_edx_enrollment_data(email, course_key):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def list_canvas_enrollments(request, course_id):
     """
     Fetch enrollees for a course in canvas and list them
@@ -51,7 +51,7 @@ def list_canvas_enrollments(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def add_canvas_enrollments(request, course_id):
     """
     Fetches enrollees for a course in canvas and enrolls those emails in the course in edX
@@ -72,7 +72,7 @@ def add_canvas_enrollments(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def list_canvas_assignments(request, course_id):
     """List Canvas assignments"""
     course_key = CourseLocator.from_string(course_id)
@@ -86,7 +86,7 @@ def list_canvas_assignments(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def list_canvas_grades(request, course_id):
     """List grades"""
     assignment_id = int(request.GET.get("assignment_id"))
@@ -101,7 +101,7 @@ def list_canvas_grades(request, course_id):
 
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def push_edx_grades(request, course_id):
     """Push user grades for all graded items in edX to Canvas"""
     course_key = CourseLocator.from_string(course_id)

--- a/lms/djangoapps/remote_gradebook/api.py
+++ b/lms/djangoapps/remote_gradebook/api.py
@@ -2,34 +2,9 @@
 API functionality for the remote gradebook app
 """
 from django.contrib.auth.models import User
-from django.http import Http404, HttpResponse, HttpResponseForbidden
-from opaque_keys.edx.keys import CourseKey
 from courseware.access import has_access
-from courseware.courses import get_course_by_id
 from grades.context import grading_context_for_course
 from student.models import CourseEnrollmentAllowed, CourseEnrollment
-
-
-def require_course_permission(permission):
-    """
-    Decorator with argument that requires a specific permission of the requesting
-    user. If the requirement is not satisfied, returns an
-    HttpResponseForbidden (403).
-
-    Assumes that request is in args[0].
-    Assumes that course_id is in kwargs['course_id'].
-    """
-    def decorator(func):
-        def wrapped(*args, **kwargs):
-            request = args[0]
-            course = get_course_by_id(CourseKey.from_string(kwargs['course_id']))
-
-            if request.user.has_perm(permission, course):
-                return func(*args, **kwargs)
-            else:
-                return HttpResponseForbidden()
-        return wrapped
-    return decorator
 
 
 def enroll_emails_in_course(emails, course_key):

--- a/lms/djangoapps/remote_gradebook/views.py
+++ b/lms/djangoapps/remote_gradebook/views.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def get_non_staff_enrollments(__, course_id):
     """
     Returns user emails that are enrolled in a course and not staff
@@ -53,7 +53,7 @@ def get_non_staff_enrollments(__, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def get_remote_gradebook_sections(request, course_id):
     """
     Returns a datatable of students and whether or not there is a match for those students
@@ -71,7 +71,7 @@ def get_remote_gradebook_sections(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def list_matching_remote_enrolled_students(request, course_id):
     """
     Returns a datatable of students and whether or not there is a match for those students
@@ -99,7 +99,7 @@ def list_matching_remote_enrolled_students(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def list_remote_students_in_section(request, course_id):
     """
     Returns a datatable of students in the remote gradebook that are enrolled in a specific section
@@ -123,7 +123,7 @@ def list_remote_students_in_section(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def add_enrollments_using_remote_gradebook(request, course_id):
     """
     Fetches enrollees for a course in a remote gradebook and enrolls those emails in the course in edX
@@ -160,7 +160,7 @@ def add_enrollments_using_remote_gradebook(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def get_assignment_choices(__, course_id):
     """
     Returns a datatable of the assignments available for this course
@@ -176,7 +176,7 @@ def get_assignment_choices(__, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def list_remote_assignments(request, course_id):
     """
     Returns a datatable of the assignments available in the remote gradebook
@@ -194,7 +194,7 @@ def list_remote_assignments(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def display_assignment_grades(request, course_id):
     """
     Returns a datatable of students' grades for an assignment in a course that matches a given course id
@@ -211,7 +211,7 @@ def display_assignment_grades(request, course_id):
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def export_assignment_grades_to_rg(request, course_id):
     """
     Exports students' grades for an assignment to the remote gradebook, then returns a
@@ -243,7 +243,7 @@ def export_assignment_grades_to_rg(request, course_id):
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.EDIT_COURSE_ACCESS)
+@require_course_permission(permissions.OVERRIDE_GRADES)
 def export_assignment_grades_csv(request, course_id):
     """
     Creates a CSV of students' grades for an assignment and returns that CSV as an HTTP response

--- a/lms/djangoapps/remote_gradebook/views.py
+++ b/lms/djangoapps/remote_gradebook/views.py
@@ -12,9 +12,10 @@ from django.views.decorators.http import require_POST
 from opaque_keys.edx.locator import CourseLocator
 from opaque_keys.edx.keys import CourseKey
 
+from lms.djangoapps.instructor.views.api import require_course_permission
+from lms.djangoapps.instructor import permissions
 import remote_gradebook.tasks
 from remote_gradebook.api import (
-    require_course_permission,
     enroll_emails_in_course,
     get_enrolled_non_staff_users,
     unenroll_non_staff_users_in_course,
@@ -28,7 +29,6 @@ from courseware.courses import get_course_by_id
 from util.json_request import JsonResponse
 from student.models import CourseEnrollment
 from instructor_task.api_helper import AlreadyRunningError
-from bridgekeeper.rules import is_staff
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def get_non_staff_enrollments(__, course_id):
     """
     Returns user emails that are enrolled in a course and not staff
@@ -53,7 +53,7 @@ def get_non_staff_enrollments(__, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def get_remote_gradebook_sections(request, course_id):
     """
     Returns a datatable of students and whether or not there is a match for those students
@@ -71,7 +71,7 @@ def get_remote_gradebook_sections(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def list_matching_remote_enrolled_students(request, course_id):
     """
     Returns a datatable of students and whether or not there is a match for those students
@@ -99,7 +99,7 @@ def list_matching_remote_enrolled_students(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def list_remote_students_in_section(request, course_id):
     """
     Returns a datatable of students in the remote gradebook that are enrolled in a specific section
@@ -123,7 +123,7 @@ def list_remote_students_in_section(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def add_enrollments_using_remote_gradebook(request, course_id):
     """
     Fetches enrollees for a course in a remote gradebook and enrolls those emails in the course in edX
@@ -160,7 +160,7 @@ def add_enrollments_using_remote_gradebook(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def get_assignment_choices(__, course_id):
     """
     Returns a datatable of the assignments available for this course
@@ -176,7 +176,7 @@ def get_assignment_choices(__, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def list_remote_assignments(request, course_id):
     """
     Returns a datatable of the assignments available in the remote gradebook
@@ -194,7 +194,7 @@ def list_remote_assignments(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def display_assignment_grades(request, course_id):
     """
     Returns a datatable of students' grades for an assignment in a course that matches a given course id
@@ -211,7 +211,7 @@ def display_assignment_grades(request, course_id):
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def export_assignment_grades_to_rg(request, course_id):
     """
     Exports students' grades for an assignment to the remote gradebook, then returns a
@@ -243,7 +243,7 @@ def export_assignment_grades_to_rg(request, course_id):
 @transaction.non_atomic_requests
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(is_staff)
+@require_course_permission(permissions.EDIT_COURSE_ACCESS)
 def export_assignment_grades_csv(request, course_id):
     """
     Creates a CSV of students' grades for an assignment and returns that CSV as an HTTP response


### PR DESCRIPTION
A couple of users have been getting 403 errors accessing the API. This replaces the staff permission check with a check for `OVERRIDE_GRADES` which is the staff permission for a course, instead of the Django admin permission