### PR TITLE
Add per_page to paginated requests

### DIFF
--- a/lms/djangoapps/canvas_integration/client.py
+++ b/lms/djangoapps/canvas_integration/client.py
@@ -27,7 +27,8 @@ class CanvasClient:
         })
         return session
 
-    def _add_per_page(self, url, per_page):
+    @staticmethod
+    def _add_per_page(url, per_page):
         """
         Add per_page query parameter to override default value of 10
 


### PR DESCRIPTION
 - This adds a per_page of 100 to URLs which use pagination to attempt to reduce the number of API calls. 
 - The `time.sleep` call was removed