### PR TITLE
Use VIEW_DASHBOARD permission for rapid_response view

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -3573,7 +3573,7 @@ def _return_csv_response(filename, header, rows):
 
 
 @ensure_csrf_cookie
-@require_course_permission(permissions.is_staff)
+@require_course_permission(permissions.VIEW_DASHBOARD)
 def get_rapid_response_report(request, course_id, run_id):  # pylint: disable=unused-argument
     """
     Return csv file corresponding to given run_id


### PR DESCRIPTION
Some instructors are getting a 403 response when they try to download the Rapid Response report. 

for example, https://odl.zendesk.com/agent/tickets/65106