### PR TITLE
Don't return output to prevent task output max size error

### DIFF
--- a/lms/djangoapps/canvas_integration/task_helpers.py
+++ b/lms/djangoapps/canvas_integration/task_helpers.py
@@ -30,31 +30,9 @@ def push_edx_grades_to_canvas(_xmodule_instance_args, _entry_id, course_id, task
     num_reports = 1
     task_progress = TaskProgress(action_name, num_reports, start_time)
     course = get_course_by_id(course_id)
-    assignment_grades_updated, created_assignments = api.push_edx_grades_to_canvas(
+    api.push_edx_grades_to_canvas(
         course=course
     )
-    results = {}
-    if assignment_grades_updated:
-        grade_update_results = {}
-        for subsection_block, grade_update_response in assignment_grades_updated.items():
-            if grade_update_response.ok:
-                message = "updated"
-            else:
-                message = {"error": grade_update_response.status_code}
-            grade_update_results[subsection_block.display_name] = message
-        results["grades"] = grade_update_results
-    if created_assignments:
-        created_assignment_results = {}
-        for subsection_block, new_assignment_response in created_assignments.items():
-            if new_assignment_response.ok:
-                message = "created"
-            else:
-                message = {"error": new_assignment_response.status_code}
-            created_assignment_results[subsection_block.display_name] = message
-        results["assignments"] = created_assignment_results
-
-    # for simplicity, only one task update for now when everything is done
     return task_progress.update_task_state(extra_meta={
-        "step": "Done",
-        "results": results
+        "step": "Done"
     })


### PR DESCRIPTION
Fixes #188 

I don't think we actually use this output anywhere except for debugging, so just don't return it