### PR TITLE
Removing code that blocks login on SSO accounts (mitx/koa)

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -670,9 +670,6 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
 
     """
     if not is_api(auth_entry) and user is not None and user.is_authenticated:
-        if not user.has_usable_password():
-            msg = "Your account is disabled"
-            return JsonResponse(msg, status=403)
         request = strategy.request if strategy else None
         # n.b. for new users, user.is_active may be False at this point; set the cookie anyways.
         if request is not None:


### PR DESCRIPTION
### Description
There was a commit that was intended to address user accounts that were disabled that breaks login for accounts that are SSO only. Deleting that code to restore functionality on our residential deployment.

### Relevant Ticket
https://github.com/mitodl/edx-platform/issues/207