### PR TITLE
Cherry-picking Sysadmin related commits

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -422,7 +422,11 @@ class MongoConnection(object):
         Insert a new structure into the database.
         """
         with TIMER.timer("insert_structure", course_context) as tagger:
-            tagger.measure("blocks", len(structure["blocks"]))
+            if structure and structure.get('blocks'):
+                block_length = len(structure['blocks'])
+            else:
+                block_length = 0
+            tagger.measure("blocks", block_length)
             self.structures.insert_one(structure_to_mongo(structure, course_context))
 
     def get_course_index(self, key, ignore_case=False):

--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -3,8 +3,9 @@ Provides a function for importing a git repository into the lms
 instance when using a mongo modulestore
 """
 
-
+from dateutil import parser
 import logging
+import json
 import os
 import re
 import subprocess
@@ -176,19 +177,8 @@ def switch_branch(branch, rdir):
         raise GitImportErrorCannotBranch()
 
 
-def add_repo(repo, rdir_in, branch=None):
-    """
-    This will add a git repo into the mongo modulestore.
-    If branch is left as None, it will fetch the most recent
-    version of the current branch.
-    """
-    # pylint: disable=too-many-statements
-
-    git_repo_dir = getattr(settings, 'GIT_REPO_DIR', DEFAULT_GIT_REPO_DIR)
-    git_import_static = getattr(settings, 'GIT_IMPORT_STATIC', True)
-    git_import_python_lib = getattr(settings, 'GIT_IMPORT_PYTHON_LIB', True)
-    python_lib_filename = getattr(settings, 'PYTHON_LIB_FILENAME', DEFAULT_PYTHON_LIB_FILENAME)
-
+def open_mongo_connection():
+    """open mongo connection for edit"""
     # Set defaults even if it isn't defined in settings
     mongo_db = {
         'host': 'localhost',
@@ -203,6 +193,35 @@ def add_repo(repo, rdir_in, branch=None):
         for config_item in ['host', 'user', 'password', 'db', 'port']:
             mongo_db[config_item] = settings.MONGODB_LOG.get(
                 config_item, mongo_db[config_item])
+
+    # store import-command-run output in mongo
+    mongouri = 'mongodb://{user}:{password}@{host}:{port}/{db}'.format(**mongo_db)
+
+    mdb = None
+    try:
+        if mongo_db['user'] and mongo_db['password']:
+            mdb = mongoengine.connect(mongo_db['db'], host=mongouri)
+        else:
+            mdb = mongoengine.connect(mongo_db['db'], host=mongo_db['host'], port=mongo_db['port'])
+    except mongoengine.connection.ConnectionError:
+        log.exception('Unable to connect to mongodb to save log, please '
+                      'check MONGODB_LOG settings')
+
+    return mdb
+
+
+def add_repo(repo, rdir_in, branch=None):
+    """
+    This will add a git repo into the mongo modulestore.
+    If branch is left as None, it will fetch the most recent
+    version of the current branch.
+    """
+    # pylint: disable=too-many-statements
+
+    git_repo_dir = getattr(settings, 'GIT_REPO_DIR', DEFAULT_GIT_REPO_DIR)
+    git_import_static = getattr(settings, 'GIT_IMPORT_STATIC', True)
+    git_import_python_lib = getattr(settings, 'GIT_IMPORT_PYTHON_LIB', True)
+    python_lib_filename = getattr(settings, 'PYTHON_LIB_FILENAME', DEFAULT_PYTHON_LIB_FILENAME)
 
     if not os.path.isdir(git_repo_dir):
         raise GitImportErrorNoDir(git_repo_dir)
@@ -238,9 +257,10 @@ def add_repo(repo, rdir_in, branch=None):
         switch_branch(branch, rdirp)
 
     # get commit id
-    cmd = ['git', 'log', '-1', '--format=%H', ]
+    cmd = ['git', 'log', '-1', '--format=format:{ "commit": "%H", "author": "%an %ae", "date": "%ad"}', ]
     try:
-        commit_id = cmd_log(cmd, cwd=rdirp)
+         git_log_json = json.loads(cmd_log(cmd, cwd=rdirp))
+         commit_id = git_log_json['commit']
     except subprocess.CalledProcessError as ex:
         log.exception(u'Unable to get git log: %r', ex.output)
         raise GitImportErrorBadRepo()
@@ -327,26 +347,22 @@ def add_repo(repo, rdir_in, branch=None):
             log.debug(subprocess.check_output(['ls', '-l', ],
                                               cwd=os.path.abspath(cdir)))
 
-    # store import-command-run output in mongo
-    mongouri = 'mongodb://{user}:{password}@{host}:{port}/{db}'.format(**mongo_db)
+    mdb = open_mongo_connection()
+    if mdb is not None:
+        cil = CourseImportLog(
+            course_id=course_key,
+            location=location,
+            repo_dir=rdir,
+            created=timezone.now(),
+            import_log=ret_import,
+            author=git_log_json['author'],
+            commit=git_log_json['commit'],
+            date=parser.parse(git_log_json['date']),
+            git_log=ret_git,
+        )
+        cil.save()
 
-    try:
-        if mongo_db['user'] and mongo_db['password']:
-            mdb = mongoengine.connect(mongo_db['db'], host=mongouri)
-        else:
-            mdb = mongoengine.connect(mongo_db['db'], host=mongo_db['host'], port=mongo_db['port'])
-    except mongoengine.connection.ConnectionFailure:
-        log.exception('Unable to connect to mongodb to save log, please '
-                      'check MONGODB_LOG settings')
-    cil = CourseImportLog(
-        course_id=course_key,
-        location=location,
-        repo_dir=rdir,
-        created=timezone.now(),
-        import_log=ret_import,
-        git_log=ret_git,
-    )
-    cil.save()
-
-    log.debug(u'saved CourseImportLog for %s', cil.course_id)
-    mdb.close()
+        log.debug('saved CourseImportLog for %s', cil.course_id)
+        mdb.disconnect()
+    else:
+        log.error('Unable to save CourseImportLog because of an error in building mongo connection')

--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -360,9 +360,10 @@ def add_repo(repo, rdir_in, branch=None):
             date=parser.parse(git_log_json['date']),
             git_log=ret_git,
         )
-        cil.save()
-
-        log.debug('saved CourseImportLog for %s', cil.course_id)
-        mdb.disconnect()
+        try:
+            cil.save()
+            log.debug(u'saved CourseImportLog for %s', cil.course_id)
+        except mongoengine.errors.ValidationError as e:
+            log.exception('Unable to save the course import log for %s.', cil.course_id)
     else:
         log.error('Unable to save CourseImportLog because of an error in building mongo connection')

--- a/lms/djangoapps/dashboard/models.py
+++ b/lms/djangoapps/dashboard/models.py
@@ -13,7 +13,7 @@ class CourseImportLog(mongoengine.Document):
     location = mongoengine.StringField(max_length=168)
     import_log = mongoengine.StringField(max_length=20 * 65535)
     git_log = mongoengine.StringField(max_length=65535)
-    repo_dir = mongoengine.StringField(max_length=128)
+    repo_dir = mongoengine.StringField(max_length=128, null=True)
     commit = mongoengine.StringField(max_length=40, null=True)
     author = mongoengine.StringField(max_length=500, null=True)
     date = mongoengine.DateTimeField()

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -323,14 +323,16 @@ class Courses(SysadminDashboardView):
     def make_datatable(self, courses=None):
         """Creates course information datatable"""
         data = []
-        mdb = git_import.open_mongo_connection()
-        if mdb is not None:
+        # mdb = git_import.open_mongo_connection()
+        # if mdb is not None:
+        if True:
             for course in self.get_courses():
                 gdir = course.id.course
                 data.append([course.display_name, text_type(course.id)]
-                            + self.git_info_for_course(gdir, course.id))
+                            + ['', '', ''])
+                            # + self.git_info_for_course(gdir, course.id))
 
-            mdb.disconnect()
+            # mdb.disconnect()
             return dict(header=[_('Course Name'),
                                 _('Directory/ID'),
                                 # Translators: "Git Commit" is a computer command; see http://gitref.org/basic/#commit

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -3,7 +3,7 @@ This module creates a sysadmin dashboard for managing and viewing
 courses.
 """
 
-
+from dateutil import parser
 import json
 import logging
 import os
@@ -15,7 +15,8 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import IntegrityError
-from django.http import Http404
+from django.http import Http404, HttpResponse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
@@ -23,6 +24,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import condition
 from django.views.generic.base import TemplateView
+from django.shortcuts import redirect
 from opaque_keys.edx.keys import CourseKey
 from path import Path as path
 from six import StringIO, text_type
@@ -162,6 +164,8 @@ class Users(SysadminDashboardView):
     def get(self, request):
         if not request.user.is_staff:
             raise Http404
+        if not request.user.is_superuser:
+            return redirect(reverse('gitlogs'))
         context = {
             'datatable': self.make_datatable(),
             'msg': self.msg,
@@ -204,32 +208,56 @@ class Courses(SysadminDashboardView):
     provides course listing information.
     """
 
-    def git_info_for_course(self, cdir):
+    def git_info_for_course(self, cdir, course_id):
         """This pulls out some git info like the last commit"""
-
-        cmd = ''
-        gdir = settings.DATA_DIR / cdir
         info = ['', '', '']
+        # only if course has git import history
+        if CourseImportLog.objects.filter(course_id=course_id).count() > 0:
+            # check if course has git commit hash
+            logs = CourseImportLog.objects.filter(
+                course_id=course_id,
+                commit__ne=None
+            ).values_list(
+                'commit',
+                'date',
+                'author'
+            ).order_by('-created').first()
 
-        # Try the data dir, then try to find it in the git import dir
-        if not gdir.exists():
-            git_repo_dir = getattr(settings, 'GIT_REPO_DIR', git_import.DEFAULT_GIT_REPO_DIR)
-            gdir = path(git_repo_dir) / cdir
-            if not gdir.exists():
-                return info
+            if logs:
+                info[0] = logs[0]
+                info[1] = logs[1]
+                info[2] = logs[2]
+            else:
+                # if a course do not have git commit hash then fetch from git and cache.
+                cmd = ''
+                gdir = settings.DATA_DIR / cdir
 
-        cmd = ['git', 'log', '-1',
+                # Try the data dir, then try to find it in the git import dir
+                if not gdir.exists():
+                    git_repo_dir = getattr(settings, 'GIT_REPO_DIR', git_import.DEFAULT_GIT_REPO_DIR)
+                    gdir = path(git_repo_dir) / cdir
+                    if not gdir.exists():
+                        return info
+
+                cmd = ['git', 'log', '-1',
                u'--format=format:{ "commit": "%H", "author": "%an %ae", "date": "%ad"}', ]
-        try:
-            output_json = json.loads(subprocess.check_output(cmd, cwd=gdir).decode('utf-8'))
-            info = [output_json['commit'],
-                    output_json['date'],
-                    output_json['author'], ]
-        except OSError as error:
-            log.warning(text_type(u"Error fetching git data: %s - %s"), text_type(cdir), text_type(error))
-        except (ValueError, subprocess.CalledProcessError):
-            pass
+                try:
+                    output_json = json.loads(subprocess.check_output(cmd, cwd=gdir).decode('utf-8'))
+                    info = [output_json['commit'],
+                            output_json['date'],
+                            output_json['author'], ]
 
+                    # cache the git log info
+                    course = CourseImportLog.objects.filter(
+                        course_id=course_id,
+                    ).order_by('-created').first()
+                    course.author = output_json['author']
+                    course.commit = output_json['commit']
+                    course.date = parser.parse(output_json['date'])
+                    course.save()
+                    log.debug('Updated git logs for course %s', course_id)
+                except (ValueError, subprocess.CalledProcessError):
+                    pass
         return info
 
     def get_course_from_git(self, gitloc, branch):
@@ -294,22 +322,25 @@ class Courses(SysadminDashboardView):
 
     def make_datatable(self, courses=None):
         """Creates course information datatable"""
-
         data = []
-        courses = courses or self.get_courses()
-        for course in courses:
-            gdir = course.id.course
-            data.append([course.display_name, text_type(course.id)]
-                        + self.git_info_for_course(gdir))
+        mdb = git_import.open_mongo_connection()
+        if mdb is not None:
+            for course in self.get_courses():
+                gdir = course.id.course
+                data.append([course.display_name, text_type(course.id)]
+                            + self.git_info_for_course(gdir, course.id))
 
-        return dict(header=[_('Course Name'),
-                            _('Directory/ID'),
-                            # Translators: "Git Commit" is a computer command; see http://gitref.org/basic/#commit
-                            _('Git Commit'),
-                            _('Last Change'),
-                            _('Last Editor')],
-                    title=_('Information about all courses'),
-                    data=data)
+            mdb.disconnect()
+            return dict(header=[_('Course Name'),
+                                _('Directory/ID'),
+                                # Translators: "Git Commit" is a computer command; see http://gitref.org/basic/#commit
+                                _('Git Commit'),
+                                _('Last Change'),
+                                _('Last Editor')],
+                        title=_('Information about all courses'),
+                        data=data)
+        else:
+            log.error('Unable to save CourseImportLog because of an error in building mongo connection')
 
     def get(self, request):
         """Displays forms and course information"""
@@ -431,34 +462,9 @@ class GitLogs(TemplateView):
             course_id = CourseKey.from_string(course_id)
 
         page_size = 10
-
-        # Set mongodb defaults even if it isn't defined in settings
-        mongo_db = {
-            'host': 'localhost',
-            'user': '',
-            'password': '',
-            'db': 'xlog',
-        }
-
-        # Allow overrides
-        if hasattr(settings, 'MONGODB_LOG'):
-            for config_item in ['host', 'user', 'password', 'db', ]:
-                mongo_db[config_item] = settings.MONGODB_LOG.get(
-                    config_item, mongo_db[config_item])
-
-        mongouri = 'mongodb://{user}:{password}@{host}/{db}'.format(**mongo_db)
-
         error_msg = ''
 
-        try:
-            if mongo_db['user'] and mongo_db['password']:
-                mdb = mongoengine.connect(mongo_db['db'], host=mongouri)
-            else:
-                mdb = mongoengine.connect(mongo_db['db'], host=mongo_db['host'])
-        except mongoengine.connection.ConnectionError:
-            log.exception('Unable to connect to mongodb to save log, '
-                          'please check MONGODB_LOG settings.')
-
+        mdb = git_import.open_mongo_connection()
         if course_id is None:
             # Require staff if not going to specific course
             if not request.user.is_staff:
@@ -491,6 +497,7 @@ class GitLogs(TemplateView):
         mdb.close()
         context = {
             'logs': logs,
+            'is_superuser': request.user.is_superuser,
             'course_id': text_type(course_id) if course_id else None,
             'error_msg': error_msg,
             'page_size': page_size

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -114,9 +114,11 @@ textarea {
       <h1>${_('Sysadmin Dashboard')}</h1>
       <hr />
       <h2 class="instructor-nav">
-        <a href="${reverse('sysadmin')}">${_('Users')}</a>
-        <a href="${reverse('sysadmin_courses')}">${_('Courses')}</a>
-        <a href="${reverse('sysadmin_staffing')}">${_('Staffing and Enrollment')}</a>
+        %if is_superuser:
+          <a href="${reverse('sysadmin')}">${_('Users')}</a>
+          <a href="${reverse('sysadmin_courses')}">${_('Courses')}</a>
+          <a href="${reverse('sysadmin_staffing')}">${_('Staffing and Enrollment')}</a>
+        %endif
         ## Translators: refers to http://git-scm.com/docs/git-log
         <a href="${reverse('gitlogs')}" class="active-section">${_('Git Logs')}</a>
       </h2>


### PR DESCRIPTION
#### Related Issues
https://github.com/mitodl/edx-platform/issues/197
https://github.com/mitodl/edx-platform/issues/199
https://github.com/mitodl/edx-platform/issues/205

#### Description
Cherry-picking Sysadmin related commits

#### Tested scenarios
- [x] User Creation/Deletion/Stats
- [x] Course Deletion/Stats/Git-import
- [x] Course Staff Stats
- [x] Git Logs Stats

#### Cherry-picked commits
```
bdfb5cb0a659ce420ee059525a948d097abf62b7	Enhance couses page performance in system admin page (#90)
330ad116f4df7736feaae4fb5c1f7b2182c4e574	Sysadmin: Only show gitlogs for non superuser
296662075bca340d327ed85f5dc12be16635e4a9	Fixing disconnect call for mongoengine
cb68be4fc16315d21a773be34ee823c34d44a565	Remove problematic disconnect call for mongoengine in git import module
0dc9076c4186b69c2519f8fa4aa17421ae30967d	Fixing bug in call to query timer when structure object is empty
78901d9e5aa3698f91e961760cd706a75e6959e7	Adding error catching for long git logs
6a9995a705967c0b0234be24278b9dbbc444523f        Hack to avoid looking up course git info for sysadmin courses
```