### PR TITLE
Adding INVITE_ONLY default option

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -288,7 +288,8 @@ def _can_enroll_courselike(user, courselike):
     if _has_staff_access_to_descriptor(user, courselike, course_key):
         return ACCESS_GRANTED
 
-    if courselike.invitation_only:
+    # Access denied when default value of COURSE_DEFAULT_INVITE_ONLY set to True
+    if settings.FEATURES.get('COURSE_DEFAULT_INVITE_ONLY') or courselike.invitation_only:
         debug("Deny: invitation only")
         return ACCESS_DENIED
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -545,6 +545,39 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         )
         self.assertFalse(access._has_access_course(user, 'enroll', course))
 
+    @patch.dict('django.conf.settings.FEATURES', {'COURSE_DEFAULT_INVITE_ONLY': False})
+    def test__course_default_invite_only_flag_false(self):
+        """Tests that default value of COURSE_DEFAULT_INVITE_ONLY as False."""
+
+        user = UserFactory.create()
+
+        course = self._mock_course(invitation=True)
+        self.assertFalse(access._has_access_course(user, 'enroll', course))
+
+        course = self._mock_course(invitation=False)
+        self.assertTrue(access._has_access_course(user, 'enroll', course))
+
+    @patch.dict('django.conf.settings.FEATURES', {'COURSE_DEFAULT_INVITE_ONLY': True})
+    def test__course_default_invite_only_flag_true(self):
+        """Tests that default value of COURSE_DEFAULT_INVITE_ONLY as True."""
+
+        user = UserFactory.create()
+
+        course = self._mock_course(invitation=True)
+        self.assertFalse(access._has_access_course(user, 'enroll', course))
+
+        course = self._mock_course(invitation=False)
+        self.assertFalse(access._has_access_course(user, 'enroll', course))
+
+    def _mock_course(self, invitation):
+        yesterday = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)
+        tomorrow = datetime.datetime.now(pytz.utc) + datetime.timedelta(days=1)
+        return Mock(
+            enrollment_start=yesterday, enrollment_end=tomorrow,
+            id=CourseLocator('edX', 'test', '2012_Fall'), enrollment_domain='',
+            invitation_only=invitation
+        )
+
     def test__user_passed_as_none(self):
         """Ensure has_access handles a user being passed as null"""
         access.has_access(None, 'staff', 'global', None)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -926,7 +926,7 @@ def course_about(request, course_id):
 
         # Used to provide context to message to student if enrollment not allowed
         can_enroll = bool(request.user.has_perm(ENROLL_IN_COURSE, course))
-        invitation_only = course.invitation_only
+        invitation_only = settings.FEATURES.get('COURSE_DEFAULT_INVITE_ONLY') or course.invitation_only
         is_course_full = CourseEnrollment.objects.is_course_full(course)
 
         # Register button should be disabled if one of the following is true:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -621,6 +621,8 @@ FEATURES = {
     # Whether to display the account deletion section the account settings page
     'ENABLE_ACCOUNT_DELETION': True,
 
+    # Set this to manage the default value across all courses in a given deployment
+    'COURSE_DEFAULT_INVITE_ONLY': False,
     # Enable feature to remove enrollments and users. Used to reset state of master's integration environments
     'ENABLE_ENROLLMENT_RESET': False,
     'DISABLE_MOBILE_COURSE_AVAILABLE': False,

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -90,7 +90,7 @@ from six import string_types
           <span class="register disabled">
             ${_("Course is full")}
           </span>
-        % elif invitation_only and not can_enroll:
+        % elif settings.FEATURES.get('COURSE_DEFAULT_INVITE_ONLY') or invitation_only and not can_enroll:
           <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
         ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
         ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click


### PR DESCRIPTION
fixes #201 and maybe https://github.mit.edu/mitx/Spring-2021/issues/9

In order to allow for preventing users accidentally enrolling in a course we are adding a flag to toggle whether courses in a given installation of edx-platform are invite only, rather than relying on setting it at the per-course level.

(cherry picked from commit 1be29e209331b6af47b102de1b1a1794439d137c)
(cherry picked from commit 2581b511ceb44c6f6677ece4bf833c556fe766f0)
(cherry picked from commit ccce55963be8bb2b4abefa5d6e709e31f63f2ff6)