### PR TITLE
Move rapid_response_xblock imports inside functions so dev.provision can succeed

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -130,7 +130,6 @@ from common.djangoapps.util.views import require_global_staff
 from xmodule.modulestore.django import modulestore
 
 from .. import permissions
-from rapid_response_xblock.utils import get_run_submission_data
 
 from .tools import (
     dump_module_extensions,
@@ -3558,4 +3557,6 @@ def get_rapid_response_report(request, course_id, run_id):  # pylint: disable=un
     Return csv file corresponding to given run_id
     """
     header = ['Date', 'Submitted Answer', 'Username', 'User Email', 'Correct']
+    from rapid_response_xblock.utils import get_run_submission_data
+
     return _return_csv_response('rapid_response_submissions.csv', header, get_run_submission_data(run_id))

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -64,7 +64,6 @@ from xmodule.html_module import HtmlBlock
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import CourseTab
 
-from rapid_response_xblock.utils import get_run_data_for_course
 
 from .tools import get_units_with_due_date, title_or_url
 from .. import permissions
@@ -860,6 +859,7 @@ def is_ecommerce_course(course_key):
 def _section_rapid_response(course_key):
     """Provide data for the rapid response dashboard section """
 
+    from rapid_response_xblock.utils import get_run_data_for_course
     section_data = {
         'section_key': 'rapid_response',
         'section_display_name': _('Rapid Responses'),


### PR DESCRIPTION
When I ran `make dev.provision` on a brand new devstack, I got this stack trace. It looks like this PR fixes the issue by preventing the import from failing, though I don't understand why `uninstall_python_packages` is importing code at all

Stack trace:

    ➜  devstack git:(master) make dev.provision
    # We provision all default services as well as 'e2e' (end-to-end tests).
    # e2e is not part of `DEFAULT_SERVICES` because it isn't a service;
    # it's just a way to tell ./provision.sh that the fake data for end-to-end
    # tests should be prepared.
    bash ./provision.sh credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+studio+e2e
    + RED='\033[0;31m'
    + GREEN='\033[0;32m'
    + YELLOW='\033[0;33m'
    + NC='\033[0m'
    + ALL_SERVICES_IN_ORDER=' lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + [[ 1 -eq 0 ]]
    + arg_string=' credentials+discovery+ecommerce+edx_notes_api+forum+frontend-app-publisher+frontend-app-learning+gradebook+lms+studio+e2e '
    + requested_services=' credentials discovery ecommerce edx_notes_api forum frontend-app-publisher frontend-app-learning gradebook lms studio e2e '
    + to_provision=' '
    + for serv in $requested_services
    + case "$serv" in
    + service=credentials
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' credentials
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=credentials
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \c\r\e\d\e\n\t\i\a\l\s\ * ]]
    + return 0
    + is_substring ' ' credentials
    + local 'str= '
    + local substr=credentials
    + [[   == *\ \c\r\e\d\e\n\t\i\a\l\s\ * ]]
    + return 1
    + to_provision=' credentials '
    + for serv in $requested_services
    + case "$serv" in
    + service=discovery
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' discovery
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=discovery
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \d\i\s\c\o\v\e\r\y\ * ]]
    + return 0
    + is_substring ' credentials ' discovery
    + local 'str= credentials '
    + local substr=discovery
    + [[  credentials  == *\ \d\i\s\c\o\v\e\r\y\ * ]]
    + return 1
    + to_provision=' credentials discovery '
    + for serv in $requested_services
    + case "$serv" in
    + service=ecommerce
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' ecommerce
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=ecommerce
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \e\c\o\m\m\e\r\c\e\ * ]]
    + return 0
    + is_substring ' credentials discovery ' ecommerce
    + local 'str= credentials discovery '
    + local substr=ecommerce
    + [[  credentials discovery  == *\ \e\c\o\m\m\e\r\c\e\ * ]]
    + return 1
    + to_provision=' credentials discovery ecommerce '
    + for serv in $requested_services
    + case "$serv" in
    + service=notes
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' notes
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=notes
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \n\o\t\e\s\ * ]]
    + return 0
    + is_substring ' credentials discovery ecommerce ' notes
    + local 'str= credentials discovery ecommerce '
    + local substr=notes
    + [[  credentials discovery ecommerce  == *\ \n\o\t\e\s\ * ]]
    + return 1
    + to_provision=' credentials discovery ecommerce notes '
    + for serv in $requested_services
    + case "$serv" in
    + service=forum
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' forum
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=forum
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \f\o\r\u\m\ * ]]
    + return 0
    + is_substring ' credentials discovery ecommerce notes ' forum
    + local 'str= credentials discovery ecommerce notes '
    + local substr=forum
    + [[  credentials discovery ecommerce notes  == *\ \f\o\r\u\m\ * ]]
    + return 1
    + to_provision=' credentials discovery ecommerce notes forum '
    + for serv in $requested_services
    + case "$serv" in
    + service=frontend-app-publisher
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' frontend-app-publisher
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=frontend-app-publisher
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \f\r\o\n\t\e\n\d\-\a\p\p\-\p\u\b\l\i\s\h\e\r\ * ]]
    + return 1
    + echo -e '\033[0;33mService '\''frontend-app-publisher'\'' either doesn'\''t exist or isn'\''t provisionable.\033[0m'
    Service 'frontend-app-publisher' either doesn't exist or isn't provisionable.
    + for serv in $requested_services
    + case "$serv" in
    + service=frontend-app-learning
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' frontend-app-learning
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=frontend-app-learning
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \f\r\o\n\t\e\n\d\-\a\p\p\-\l\e\a\r\n\i\n\g\ * ]]
    + return 1
    + echo -e '\033[0;33mService '\''frontend-app-learning'\'' either doesn'\''t exist or isn'\''t provisionable.\033[0m'
    Service 'frontend-app-learning' either doesn't exist or isn't provisionable.
    + for serv in $requested_services
    + case "$serv" in
    + service=gradebook
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' gradebook
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=gradebook
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \g\r\a\d\e\b\o\o\k\ * ]]
    + return 1
    + echo -e '\033[0;33mService '\''gradebook'\'' either doesn'\''t exist or isn'\''t provisionable.\033[0m'
    Service 'gradebook' either doesn't exist or isn't provisionable.
    + for serv in $requested_services
    + case "$serv" in
    + service=lms
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' lms
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=lms
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \l\m\s\ * ]]
    + return 0
    + is_substring ' credentials discovery ecommerce notes forum ' lms
    + local 'str= credentials discovery ecommerce notes forum '
    + local substr=lms
    + [[  credentials discovery ecommerce notes forum  == *\ \l\m\s\ * ]]
    + return 1
    + to_provision=' credentials discovery ecommerce notes forum lms '
    + for serv in $requested_services
    + case "$serv" in
    + echo -e '\033[0;33mStudio is provisioned alongside LMS.\nPass '\''lms'\'' as an argument to ensure that Studio is provisioned.\033[0m'
    Studio is provisioned alongside LMS.
    Pass 'lms' as an argument to ensure that Studio is provisioned.
    + continue
    + for serv in $requested_services
    + case "$serv" in
    + service=e2e
    + is_substring ' lms ecommerce discovery credentials e2e forum notes registrar xqueue  ' e2e
    + local 'str= lms ecommerce discovery credentials e2e forum notes registrar xqueue  '
    + local substr=e2e
    + [[  lms ecommerce discovery credentials e2e forum notes registrar xqueue   == *\ \e\2\e\ * ]]
    + return 0
    + is_substring ' credentials discovery ecommerce notes forum lms ' e2e
    + local 'str= credentials discovery ecommerce notes forum lms '
    + local substr=e2e
    + [[  credentials discovery ecommerce notes forum lms  == *\ \e\2\e\ * ]]
    + return 1
    + to_provision=' credentials discovery ecommerce notes forum lms e2e '
    + to_provision_ordered=' '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' lms
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=lms
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \l\m\s\ * ]]
    + return 0
    + to_provision_ordered=' lms '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' ecommerce
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=ecommerce
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \e\c\o\m\m\e\r\c\e\ * ]]
    + return 0
    + to_provision_ordered=' lms ecommerce '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' discovery
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=discovery
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \d\i\s\c\o\v\e\r\y\ * ]]
    + return 0
    + to_provision_ordered=' lms ecommerce discovery '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' credentials
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=credentials
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \c\r\e\d\e\n\t\i\a\l\s\ * ]]
    + return 0
    + to_provision_ordered=' lms ecommerce discovery credentials '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' e2e
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=e2e
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \e\2\e\ * ]]
    + return 0
    + to_provision_ordered=' lms ecommerce discovery credentials e2e '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' forum
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=forum
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \f\o\r\u\m\ * ]]
    + return 0
    + to_provision_ordered=' lms ecommerce discovery credentials e2e forum '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' notes
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=notes
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \n\o\t\e\s\ * ]]
    + return 0
    + to_provision_ordered=' lms ecommerce discovery credentials e2e forum notes '
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' registrar
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=registrar
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \r\e\g\i\s\t\r\a\r\ * ]]
    + return 1
    + for ordered_service in $ALL_SERVICES_IN_ORDER
    + is_substring ' credentials discovery ecommerce notes forum lms e2e ' xqueue
    + local 'str= credentials discovery ecommerce notes forum lms e2e '
    + local substr=xqueue
    + [[  credentials discovery ecommerce notes forum lms e2e  == *\ \x\q\u\e\u\e\ * ]]
    + return 1
    + [[  lms ecommerce discovery credentials e2e forum notes  = \  ]]
    + echo -e '\033[0;32mWill provision the following:\n   lms ecommerce discovery credentials e2e forum notes \033[0m'
    Will provision the following:
       lms ecommerce discovery credentials e2e forum notes 
    + docker-compose up -d mysql
    Creating network "devstack_default" with the default driver
    Creating volume "devstack_discovery_assets" with default driver
    Creating volume "devstack_edxapp_lms_assets" with default driver
    Creating volume "devstack_edxapp_studio_assets" with default driver
    Creating volume "devstack_elasticsearch_data" with default driver
    Creating volume "devstack_elasticsearch7_data" with default driver
    Creating volume "devstack_mongo_data" with default driver
    Creating volume "devstack_mysql_data" with default driver
    Creating volume "devstack_mysql57_data" with default driver
    Creating volume "devstack_devpi_data" with default driver
    Creating volume "devstack_credentials_node_modules" with default driver
    Creating volume "devstack_discovery_node_modules" with default driver
    Creating volume "devstack_ecommerce_node_modules" with default driver
    Creating volume "devstack_edxapp_media" with default driver
    Creating volume "devstack_edxapp_node_modules" with default driver
    Creating volume "devstack_edxapp_uploads" with default driver
    Creating volume "devstack_gradebook_node_modules" with default driver
    Creating volume "devstack_program_console_node_modules" with default driver
    Creating volume "devstack_frontend_app_publisher_node_modules" with default driver
    Creating volume "devstack_frontend_app_learning_node_modules" with default driver
    Creating volume "devstack_course_authoring_node_modules" with default driver
    Creating volume "devstack_frontend_app_library_authoring_node_modules" with default driver
    Creating volume "devstack_credentials_tox" with default driver
    Creating volume "devstack_discovery_tox" with default driver
    Creating volume "devstack_ecommerce_tox" with default driver
    Creating volume "devstack_edxapp_tox" with default driver
    Creating volume "devstack_gradebook_tox" with default driver
    Creating volume "devstack_program_console_tox" with default driver
    Creating edx.devstack.mysql ... done
    + docker-compose up -d mysql57
    Creating edx.devstack.mysql57 ... done
    + needs_mongo ' lms ecommerce discovery credentials e2e forum notes '
    + local 'services= lms ecommerce discovery credentials e2e forum notes '
    + is_substring ' lms ecommerce discovery credentials e2e forum notes ' lms
    + local 'str= lms ecommerce discovery credentials e2e forum notes '
    + local substr=lms
    + [[  lms ecommerce discovery credentials e2e forum notes  == *\ \l\m\s\ * ]]
    + return 0
    + return 0
    + docker-compose up -d mongo
    Creating edx.devstack.mongo ... done
    + echo '\033[0;32mWaiting for MySQL 5.6.\033[0m'
    \033[0;32mWaiting for MySQL 5.6.\033[0m
    + docker-compose exec -T mysql bash -c 'mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = '\''root'\'')"'
    + printf .
    .+ sleep 1
    + docker-compose exec -T mysql bash -c 'mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = '\''root'\'')"'
    + echo '\033[0;32mWaiting for MySQL 5.7.\033[0m'
    \033[0;32mWaiting for MySQL 5.7.\033[0m
    + docker-compose exec -T mysql57 bash -c 'mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = '\''root'\'')"'
    + printf .
    .+ sleep 1
    + docker-compose exec -T mysql57 bash -c 'mysql -uroot -se "SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = '\''root'\'')"'
    + sleep 20
    + echo -e '\033[0;32mMySQL ready.\033[0m'
    MySQL ready.
    + echo -e '\033[0;32mEnsuring MySQL 5.6 databases and users exist...\033[0m'
    Ensuring MySQL 5.6 databases and users exist...
    + docker-compose exec -T mysql bash -c 'mysql -uroot mysql'
    + echo -e '\033[0;32mEnsuring MySQL 5.7 databases and users exist...\033[0m'
    Ensuring MySQL 5.7 databases and users exist...
    + docker-compose exec -T mysql57 bash -c 'mysql -uroot mysql'
    + needs_mongo ' lms ecommerce discovery credentials e2e forum notes '
    + local 'services= lms ecommerce discovery credentials e2e forum notes '
    + is_substring ' lms ecommerce discovery credentials e2e forum notes ' lms
    + local 'str= lms ecommerce discovery credentials e2e forum notes '
    + local substr=lms
    + [[  lms ecommerce discovery credentials e2e forum notes  == *\ \l\m\s\ * ]]
    + return 0
    + return 0
    + echo -e '\033[0;32mWaiting for MongoDB...\033[0m'
    Waiting for MongoDB...
    + docker-compose exec -T mongo mongo --eval 'db.serverStatus()'
    + echo -e '\033[0;32mMongoDB ready.\033[0m'
    MongoDB ready.
    + echo -e '\033[0;32mCreating MongoDB users...\033[0m'
    Creating MongoDB users...
    + docker-compose exec -T mongo bash -c mongo
    MongoDB shell version v4.0.22
    connecting to: mongodb://127.0.0.1:27017/?gssapiServiceName=mongodb
    Implicit session: session { "id" : UUID("91b9bbd4-65c9-458d-ba84-b75beeab774d") }
    MongoDB server version: 4.0.22
    connection to 127.0.0.1:27017
    [
    	{
    		"user" : "admin",
    		"pwd" : "password",
    		"roles" : [
    			"root"
    		],
    		"database" : "admin"
    	},
    	{
    		"user" : "cs_comments_service",
    		"pwd" : "password",
    		"roles" : [
    			"readWrite"
    		],
    		"database" : "cs_comments_service"
    	},
    	{
    		"user" : "edxapp",
    		"pwd" : "password",
    		"roles" : [
    			"readWrite"
    		],
    		"database" : "edxapp"
    	}
    ]
    Successfully added user: { "user" : "admin", "roles" : [ "root" ] }
    Successfully added user: { "user" : "cs_comments_service", "roles" : [ "readWrite" ] }
    Successfully added user: { "user" : "edxapp", "roles" : [ "readWrite" ] }
    bye
    + for service in $to_provision_ordered
    + echo -e '\033[0;32m Provisioning lms...\033[0m'
     Provisioning lms...
    + ./provision-lms.sh
    ++ apps=(lms studio)
    ++ ./load-db.sh edxapp
    Loading the edxapp database...
    Finished loading the edxapp database!
    ++ ./load-db.sh edxapp_csmh
    Loading the edxapp_csmh database...
    Finished loading the edxapp_csmh database!
    ++ for app in "${apps[@]}"
    ++ docker-compose up -d lms
    edx.devstack.mongo is up-to-date
    edx.devstack.mysql57 is up-to-date
    Creating edx.devstack.memcached      ... done
    Creating edx.devstack.chrome         ... done
    Creating edx.devstack.elasticsearch7 ... done
    Creating edx.devstack.devpi          ... done
    Creating edx.devstack.firefox        ... done
    Creating edx.devstack.discovery      ... done
    Creating edx.devstack.forum          ... done
    Creating edx.devstack.lms            ... done
    ++ for app in "${apps[@]}"
    ++ docker-compose up -d studio
    edx.devstack.mysql57 is up-to-date
    edx.devstack.chrome is up-to-date
    edx.devstack.elasticsearch7 is up-to-date
    edx.devstack.firefox is up-to-date
    edx.devstack.memcached is up-to-date
    edx.devstack.devpi is up-to-date
    edx.devstack.mongo is up-to-date
    edx.devstack.discovery is up-to-date
    edx.devstack.forum is up-to-date
    edx.devstack.lms is up-to-date
    Creating edx.devstack.studio ... done
    ++ docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
    ---> pavelib.prereqs.install_prereqs
    ---> pavelib.prereqs.install_node_prereqs
    Node prereqs unchanged, skipping...
    ---> pavelib.prereqs.install_python_prereqs
    ---> pavelib.prereqs.uninstall_python_packages
    NO_PYTHON_UNINSTALL is set. No attempts will be made to uninstall old Python libs.
    pip install -q --disable-pip-version-check --exists-action w -r requirements/edx/development.txt
      WARNING: Requested coverage_pytest_plugin==0.0 from git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0 (from -r requirements/edx/development.txt (line 50)), but installing version 0.1
      WARNING: Requested django-ratelimit-backend==2.0.1a5 from git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5 (from -r requirements/edx/development.txt (line 82)), but installing version 2.0.1
    pip freeze > /edx/app/edxapp/edx-platform/test_root/log/pip_freeze.log
    ********************************************************************************
    * WARNING: Mac users should run this from both the lms and studio shells
    * in docker devstack to avoid startup errors that kill your CPU.
    * For more details, see:
    * https://github.com/edx/devstack#docker-is-using-lots-of-cpu-time-when-it-should-be-idle
    ********************************************************************************
    ++ docker-compose restart lms
    Restarting edx.devstack.lms ... done
    ++ docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && paver update_db --settings devstack_docker'
    ---> pavelib.servers.update_db
    ---> pavelib.prereqs.install_prereqs
    ---> pavelib.prereqs.install_node_prereqs
    Node prereqs unchanged, skipping...
    ---> pavelib.prereqs.install_python_prereqs
    ---> pavelib.prereqs.uninstall_python_packages
    NO_PYTHON_UNINSTALL is set. No attempts will be made to uninstall old Python libs.
    Python prereqs unchanged, skipping...
    pip freeze > /edx/app/edxapp/edx-platform/test_root/log/pip_freeze.log
    ********************************************************************************
    * WARNING: Mac users should run this from both the lms and studio shells
    * in docker devstack to avoid startup errors that kill your CPU.
    * For more details, see:
    * https://github.com/edx/devstack#docker-is-using-lots-of-cpu-time-when-it-should-be-idle
    ********************************************************************************
    NO_EDXAPP_SUDO=1 EDX_PLATFORM_SETTINGS_OVERRIDE=devstack_docker /edx/bin/edxapp-migrate-lms --traceback --pythonpath=. 
    2021-01-27 20:33:43,865 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/console.py:84: DeprecationWarning: `formatargspec` is deprecated since Python 3.5. Use `signature` and the `Signature` object directly
      prototype = wrapper.__name__[3:] + ' ' + inspect.formatargspec(
    
    2021-01-27 20:33:46,438 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/sorl/thumbnail/conf/__init__.py:16: RemovedInDjango30Warning: The DEFAULT_CONTENT_TYPE setting is deprecated.
      setattr(self, attr, getattr(obj, attr))
    
    2021-01-27 20:33:46,438 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/sorl/thumbnail/conf/__init__.py:16: RemovedInDjango31Warning: The FILE_CHARSET setting is deprecated. Starting with Django 3.1, all files read from disk must be UTF-8 encoded.
      setattr(self, attr, getattr(obj, attr))
    
    2021-01-27 20:33:46,529 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/utils.py:63: DeprecatedEdxPlatformImportWarning: Importing student instead of common.djangoapps.student is deprecated
      from student.api import (
    
    2021-01-27 20:33:46,530 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/utils.py:63: DeprecatedEdxPlatformImportWarning: Importing student.api instead of common.djangoapps.student.api is deprecated
      from student.api import (
    
    2021-01-27 20:33:46,531 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/utils.py:74: DeprecatedEdxPlatformImportWarning: Importing third_party_auth instead of common.djangoapps.third_party_auth is deprecated
      from third_party_auth.provider import Registry  # pylint: disable=unused-import
    
    2021-01-27 20:33:46,532 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/utils.py:74: DeprecatedEdxPlatformImportWarning: Importing third_party_auth.provider instead of common.djangoapps.third_party_auth.provider is deprecated
      from third_party_auth.provider import Registry  # pylint: disable=unused-import
    
    2021-01-27 20:33:46,532 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/utils.py:81: DeprecatedEdxPlatformImportWarning: Importing track instead of common.djangoapps.track is deprecated
      from track import segment
    
    2021-01-27 20:33:46,735 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/admin/forms.py:35: DeprecatedEdxPlatformImportWarning: Importing third_party_auth.models instead of common.djangoapps.third_party_auth.models is deprecated
      from third_party_auth.models import SAMLProviderConfig as saml_provider_configuration
    
    2021-01-27 20:33:47,074 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/signals.py:40: DeprecatedEdxPlatformImportWarning: Importing student.models instead of common.djangoapps.student.models is deprecated
      from student.models import CourseEnrollment
    
    2021-01-27 20:33:48,514 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/api.py:49: DeprecatedEdxPlatformImportWarning: Importing util instead of common.djangoapps.util is deprecated
      from util import milestones_helpers
    
    Traceback (most recent call last):
      File "manage.py", line 123, in <module>
        execute_from_command_line([sys.argv[0]] + django_args)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
        utility.execute()
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/__init__.py", line 375, in execute
        self.fetch_command(subcommand).run_from_argv(self.argv)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/base.py", line 323, in run_from_argv
        self.execute(*args, **cmd_options)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/base.py", line 361, in execute
        self.check()
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/base.py", line 387, in check
        all_issues = self._run_checks(
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/commands/migrate.py", line 65, in _run_checks
        issues.extend(super()._run_checks(**kwargs))
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/base.py", line 377, in _run_checks
        return checks.run_checks(**kwargs)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/checks/registry.py", line 72, in run_checks
        new_errors = check(app_configs=app_configs)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/checks/urls.py", line 13, in check_url_config
        return check_resolver(resolver)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/checks/urls.py", line 23, in check_resolver
        return check_method()
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/urls/resolvers.py", line 399, in check
        for pattern in self.url_patterns:
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/functional.py", line 80, in __get__
        res = instance.__dict__[self.name] = self.func(instance)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/urls/resolvers.py", line 584, in url_patterns
        patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/functional.py", line 80, in __get__
        res = instance.__dict__[self.name] = self.func(instance)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/urls/resolvers.py", line 577, in urlconf_module
        return import_module(self.urlconf_name)
      File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/importlib/__init__.py", line 127, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
      File "<frozen importlib._bootstrap>", line 991, in _find_and_load
      File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
      File "<frozen importlib._bootstrap_external>", line 783, in exec_module
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "/edx/app/edxapp/edx-platform/lms/urls.py", line 16, in <module>
        from lms.djangoapps.branding import views as branding_views
      File "/edx/app/edxapp/edx-platform/lms/djangoapps/branding/views.py", line 20, in <module>
        import lms.djangoapps.courseware.views.views as courseware_views
      File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/views.py", line 91, in <module>
        from lms.djangoapps.instructor.views.api import require_global_staff
      File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor/views/api.py", line 133, in <module>
        from rapid_response_xblock.utils import get_run_submission_data
    ModuleNotFoundError: No module named 'rapid_response_xblock'
    
    
    Captured Task Output:
    ---------------------
    
    ---> pavelib.servers.update_db
    ---> pavelib.prereqs.install_prereqs
    ---> pavelib.prereqs.install_node_prereqs
    ---> pavelib.prereqs.install_python_prereqs
    ---> pavelib.prereqs.uninstall_python_packages
    pip freeze > /edx/app/edxapp/edx-platform/test_root/log/pip_freeze.log
    NO_EDXAPP_SUDO=1 EDX_PLATFORM_SETTINGS_OVERRIDE=devstack_docker /edx/bin/edxapp-migrate-lms --traceback --pythonpath=. 
    
    Build failed running pavelib.servers.update_db: Subprocess return code: 1
    make: *** [Makefile:220: dev.provision] Error 1
    
