### PR TITLE
add LOGOUT_REDIRECT_URL to be used for logout redirection

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -977,10 +977,14 @@ COMPLETION_VIDEO_COMPLETE_PERCENTAGE = ENV_TOKENS.get('COMPLETION_VIDEO_COMPLETE
 COMPLETION_VIDEO_COMPLETE_PERCENTAGE = ENV_TOKENS.get('COMPLETION_BY_VIEWING_DELAY_MS',
                                                       COMPLETION_BY_VIEWING_DELAY_MS)
 
-############## xPRO Base URL ############################
+############## xPRO Specific Variables ############################
 # This should be defined in ansible_vars for the xPRO app
 XPRO_BASE_URL = ENV_TOKENS.get('XPRO_BASE_URL')
 LOGIN_REDIRECT_WHITELIST = ENV_TOKENS.get(
     'LOGIN_REDIRECT_WHITELIST',
     LOGIN_REDIRECT_WHITELIST
+)
+LOGOUT_REDIRECT_URL = ENV_TOKENS.get(
+    'LOGOUT_REDIRECT_URL',
+    ''
 )

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -47,6 +47,10 @@ class LogoutView(TemplateView):
         """
         target_url = self.request.GET.get('redirect_url') or self.request.GET.get('next')
 
+        # In case no target-url is specified in request, LOGOUT_REDIRECT_URL will be used instead
+        if not target_url and settings.LOGOUT_REDIRECT_URL:
+            target_url = settings.LOGOUT_REDIRECT_URL
+
         #  Some third party apps do not build URLs correctly and send next query param without URL-encoding, resulting
         #  all plus('+') signs interpreted as space(' ') in the process of URL-decoding
         #  for example if we hit on:


### PR DESCRIPTION
#### Related Ticket
https://github.com/mitodl/mitxpro/issues/1931
https://github.mit.edu/xpro/xpro-issues/issues/246

#### What does this PR do?
If `redirect_url` is not specified in the `logout URL (/logout)` then the user is by default redirected to `edX's dashboard (/dashboard)`. I have added a new variable named `LOGOUT_REDIRECT_URL` which can be used as default redirection-url instead of dashboard.

#### How to test this PR?
* Set `LOGOUT_REDIRECT_URL` URL in edx-platform's `lms.yml`.
* Add the domain of `LOGOUT_REDIRECT_URL` into `LOGIN_REDIRECT_WHITELIST` in `lms.yml`.
* Login into edX.
* Logout using drop-down button.
* After logging out, you should be redirected to the `LOGOUT_REDIRECT_URL`.