### PR TITLE
Changed relative to absolute path

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -749,7 +749,7 @@ if FEATURES.get('CUSTOM_COURSES_EDX'):
 ##### Individual Due Date Extensions #####
 if FEATURES.get('INDIVIDUAL_DUE_DATES'):
     FIELD_OVERRIDE_PROVIDERS += (
-        'courseware.student_field_overrides.IndividualStudentOverrideProvider',
+        'lms.djangoapps.courseware.student_field_overrides.IndividualStudentOverrideProvider',
     )
 
 ##### Show Answer Override for Self-Paced Courses #####


### PR DESCRIPTION
In our testing, loading any course pages was throwing a 500 error with the stack trace below:
`2021-05-17 22:00:43,433 ERROR 177893 [edx.courseware] [user 15662] [ip x.x.x.x] views.py:723 - Error in /courses/course-v1:MITx+8.01+F2020/courseware/801r_Intro/seq-about/: user=shaidar, effective_user=shaidar, course=course-v1:MITx+8.01+F2020
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 151, in get
    return self.render(request)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 216, in render
    self._prefetch_and_bind_course(request)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 373, in _prefetch_and_bind_course
    self.course = get_module_for_descriptor(
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 417, in get_module_for_descriptor
    return get_module_for_descriptor_internal(
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 885, in get_module_for_descriptor_internal
    descriptor.bind_for_student(
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 294, in bind_for_student
    super().bind_for_student(xmodule_runtime, user_id, wrappers)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 709, in bind_for_student
    wrapped_field_data = wrapper(wrapped_field_data)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/field_overrides.py", line 163, in wrap
    cls.provider_classes = tuple(resolve_dotted(name) for name in settings.FIELD_OVERRIDE_PROVIDERS)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/field_overrides.py", line 163, in <genexpr>
    cls.provider_classes = tuple(resolve_dotted(name) for name in settings.FIELD_OVERRIDE_PROVIDERS)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/field_overrides.py", line 41, in resolve_dotted
    target = __import__(path)
  File "/edx/app/edxapp/edx-platform/import_shims/lms/courseware/__init__.py", line 6, in <module>
    warn_deprecated_import('courseware', 'lms.djangoapps.courseware')
  File "/edx/app/edxapp/edx-platform/import_shims/warn.py", line 37, in warn_deprecated_import
    raise DeprecatedEdxPlatformImportError(old_import, new_import)
import_shims.warn.DeprecatedEdxPlatformImportError: Importing courseware instead of lms.djangoapps.courseware is deprecated`

This change fixes the relative path to an absolute one and I've tested it on QA which seems to have resolved the problem.
