### PR TITLE
Fix capa report generation issue

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -657,8 +657,7 @@ class LoncapaProblem(object):
         if isinstance(current_answer, list):
             # Multiple answers. This case happens e.g. in multiple choice problems
             answer_text = ", ".join(
-                self.find_answer_text(answer_id, answer) or 'No Answer Recorded'
-                for answer in current_answer
+                self.find_answer_text(answer_id, answer) for answer in current_answer
             )
 
         elif isinstance(current_answer, six.string_types) and current_answer.startswith('choice_'):
@@ -668,13 +667,17 @@ class LoncapaProblem(object):
                 answer_id=answer_id,
                 choice_number=current_answer
             ))
-            if len(elems) == 1:
+            if len(elems) == 0:
+                log.warning("Answer Text Missing for answer id: %s and choice number: %s", answer_id, current_answer)
+                answer_text = "Answer Text Missing"
+            elif len(elems) == 1:
                 choicegroup = elems[0].getparent()
                 input_cls = inputtypes.registry.get_class_for_tag(choicegroup.tag)
                 choices_map = dict(input_cls.extract_choices(choicegroup, self.capa_system.i18n, text_only=True))
-                answer_text = choices_map[current_answer]
+                answer_text = choices_map.get(current_answer, "Answer Text Missing")
             else:
-                answer_text = 'Answer Text Missing'
+                log.warning("Multiple answers found for answer id: %s and choice number: %s", answer_id, current_answer)
+                answer_text = "Multiple answers found"
 
         elif isinstance(current_answer, six.string_types):
             # Already a string with the answer
@@ -683,7 +686,7 @@ class LoncapaProblem(object):
         else:
             raise NotImplementedError()
 
-        return answer_text
+        return answer_text or "Answer Text Missing"
 
     def do_targeted_feedback(self, tree):
         """

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -668,11 +668,13 @@ class LoncapaProblem(object):
                 answer_id=answer_id,
                 choice_number=current_answer
             ))
-            assert len(elems) == 1
-            choicegroup = elems[0].getparent()
-            input_cls = inputtypes.registry.get_class_for_tag(choicegroup.tag)
-            choices_map = dict(input_cls.extract_choices(choicegroup, self.capa_system.i18n, text_only=True))
-            answer_text = choices_map[current_answer]
+            if len(elems) == 1:
+                choicegroup = elems[0].getparent()
+                input_cls = inputtypes.registry.get_class_for_tag(choicegroup.tag)
+                choices_map = dict(input_cls.extract_choices(choicegroup, self.capa_system.i18n, text_only=True))
+                answer_text = choices_map[current_answer]
+            else:
+                answer_text = 'Answer Text Missing'
 
         elif isinstance(current_answer, six.string_types):
             # Already a string with the answer

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -657,7 +657,8 @@ class LoncapaProblem(object):
         if isinstance(current_answer, list):
             # Multiple answers. This case happens e.g. in multiple choice problems
             answer_text = ", ".join(
-                self.find_answer_text(answer_id, answer) for answer in current_answer
+                self.find_answer_text(answer_id, answer) or 'No Answer Recorded'
+                for answer in current_answer
             )
 
         elif isinstance(current_answer, six.string_types) and current_answer.startswith('choice_'):


### PR DESCRIPTION
### Description
Fixes Capa questions report generation issues by providing a default value for the problems having no text values for answer options.

### Related Issues
https://github.com/mitodl/edx-platform/issues/262
https://github.com/mitodl/edx-platform/pull/239

### How to test?
#### Test 1:
**Generate the issue without this branch's fix:**
1) Create a Checkbox Problem on studio
2) Don't put any text against one of the options
![image](https://user-images.githubusercontent.com/42243411/107644036-b906ee00-6c98-11eb-9616-7d064a2871f3.png)
3) Through LMS select that option with no text
4) Go to `Data Download` under `Instructor` tab
5) Under the `Reports` section, select the Problem and press `Create a report of problem responses`
The error will be generated.

**Now use this branch and try downloading the report again, it should be fixed now.**

#### Test 2:
**Generate the issue without this branch's fix:**
1) Create a checkboxes problem
2) Add **N** options under that problem (where **N** is a number)
3) Go to LMS, select and submit **N**th option
4) Go back to the studio and update the question by removing the **N**th option (now the total options will be **N-1**)
5) Try generating a response report for that problem, it will give `Error: There was an error generating your report.` error.

**Now use this branch and try downloading the report again, it should be fixed now.**

