### PR TITLE
fix: hide canvas tab if there is no course ID set in advanced setting

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -149,7 +149,7 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
     if settings.FEATURES.get('ENABLE_INSTRUCTOR_REMOTE_GRADEBOOK_CONTROLS', False):
         sections.append(_section_remote_gradebook(course))
 
-    if settings.FEATURES.get("ENABLE_CANVAS_INTEGRATION", False):
+    if settings.FEATURES.get("ENABLE_CANVAS_INTEGRATION", False) and course.canvas_course_id:
         sections.append(_section_canvas_integration(course))
 
     analytics_dashboard_message = None


### PR DESCRIPTION
#### Related Ticket:
#182

#### What this PR does:

It hides the `Canvas` tab on the instructor dashboard page if there is not `Canvas Course Id` set in advanced settings of the course in the studio.

#### How to test:
- Set `ENABLE_CANVAS_INTEGRATION` to true in `lms.yml` & `studio.yml`
- Set arbitrary values `CANVAS_ACCESS_TOKEN` and `CANVAS_BASE_URL` if you'd like
- Set `Canvas Course Id` in the studio and then visit the `Instructor Dashboard` tab in LMS, You should see the `Canvas` Tab on the instructor dashboard page.
- Unset the `Canvas Course Id` in the studio and the `Canvas` tab should no more be visible

More details can be seen on the ticket #182 


#### Screenshots:
**When Couse Id is set**

<img width="1436" alt="Screenshot 2021-06-04 at 6 06 55 PM" src="https://user-images.githubusercontent.com/34372316/120805984-c570c880-c55f-11eb-822c-f87d93e4b51e.png">

**When No Course Id is set**
<img width="1440" alt="Screenshot 2021-06-04 at 6 07 19 PM" src="https://user-images.githubusercontent.com/34372316/120806003-c9044f80-c55f-11eb-9a7b-4b63fe03cfb4.png">

