### PR TITLE
feat: Added Canvas support

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -472,6 +472,13 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         ),
         scope=Scope.settings
     )
+    canvas_course_id = Integer(
+        display_name=_("Canvas Course Id"),
+        help=_(
+            "The id for the corresponding course on Canvas"
+        ),
+        scope=Scope.settings
+    )
     enable_ccx = Boolean(
         # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content. CCX Coach is
         # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2156,6 +2156,7 @@ def _list_instructor_tasks(request, course_id):
 
     Internal function with common code for both DRF and and tradition views.
     """
+    include_canvas = request.GET.get('include_canvas') is not None
     course_id = CourseKey.from_string(course_id)
     params = getattr(request, 'query_params', request.POST)
     problem_location_str = strip_if_string(params.get('problem_location_str', False))
@@ -2179,6 +2180,11 @@ def _list_instructor_tasks(request, course_id):
         else:
             # Specifying for single problem's history
             tasks = task_api.get_instructor_task_history(course_id, module_state_key)
+    elif include_canvas:
+        tasks = task_api.get_running_instructor_canvas_tasks(
+            course_id,
+            user=request.user
+        )
     else:
         # If no problem or student, just get currently running tasks
         tasks = task_api.get_running_instructor_tasks(course_id)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -150,6 +150,9 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
     if access['data_researcher']:
         sections.append(_section_data_download(course, access))
 
+    if 'ol_openedx_canvas_integration.app.CanvasIntegrationConfig' in settings.INSTALLED_APPS and course.canvas_course_id:  # pylint: disable=line-too-long
+        sections.append(_section_canvas_integration(course))
+
     analytics_dashboard_message = None
     if show_analytics_dashboard_message(course_key) and (access['staff'] or access['instructor']):
         # Construct a URL to the external analytics dashboard
@@ -643,6 +646,28 @@ def _section_data_download(course, access):
     if not access.get('data_researcher'):
         section_data['is_hidden'] = True
     return section_data
+
+
+def _section_canvas_integration(course):
+    """ Provide data for the canvas dashboard section """
+    return {
+        'section_key': 'canvas_integration',
+        'section_display_name': _('Canvas'),
+        'course': course,
+        'add_canvas_enrollments_url': reverse(
+            'add_canvas_enrollments', kwargs={'course_id': course.id}
+        ),
+        "list_canvas_enrollments_url": reverse("list_canvas_enrollments", kwargs={"course_id": course.id}),
+        "list_canvas_assignments_url": reverse("list_canvas_assignments", kwargs={"course_id": course.id}),
+        "list_canvas_grades_url": reverse("list_canvas_grades", kwargs={"course_id": course.id}),
+        'list_instructor_tasks_url': '{}?include_canvas=true'.format(reverse(
+            'list_instructor_tasks',
+            kwargs={'course_id': course.id}
+        )),
+        "push_edx_grades_url": reverse(
+            "push_edx_grades", kwargs={"course_id": course.id}
+        ),
+    }
 
 
 def null_applicable_aside_types(block):  # pylint: disable=unused-argument

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -6,10 +6,11 @@ already been submitted, filtered either by running state or input
 arguments.
 
 """
-
+import datetime
 
 import hashlib
 from collections import Counter
+from pytz import UTC
 
 from celery.states import READY_STATES
 
@@ -66,6 +67,34 @@ def get_running_instructor_tasks(course_id):
     for state in READY_STATES:
         instructor_tasks = instructor_tasks.exclude(task_state=state)
     return instructor_tasks.order_by('-id')
+
+
+def _get_filtered_instructor_tasks(course_id, user, task_types):
+    """
+    Returns a filtered query of InstructorTasks based on the course, user, and desired task types
+    """
+    instructor_tasks = get_running_instructor_tasks(course_id)
+    now = datetime.datetime.now(UTC)
+    filtered_tasks = InstructorTask.objects.filter(
+        course_id=course_id,
+        task_type__in=task_types,
+        updated__lte=now,
+        updated__gte=now - datetime.timedelta(days=2),
+        requester=user
+    ).order_by('-updated')
+
+    return (instructor_tasks | filtered_tasks).distinct()[0:3]
+
+
+def get_running_instructor_canvas_tasks(course_id, user):
+    """
+    Returns a query of InstructorTask objects of running tasks for a given course
+    including canvas-specific tasks.
+    """
+    # Inline import because we will install the plugin separately
+    from ol_openedx_canvas_integration.constants import CANVAS_TASK_TYPES  # pylint: disable=import-error
+
+    return _get_filtered_instructor_tasks(course_id, user, CANVAS_TASK_TYPES)
 
 
 def get_instructor_task_history(course_id, usage_key=None, student=None, task_type=None):

--- a/lms/djangoapps/instructor_task/views.py
+++ b/lms/djangoapps/instructor_task/views.py
@@ -138,7 +138,9 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
 
     student = None
     problem_url = None
+    entrance_exam_url = None
     email_id = None
+    course_id = None
     try:
         task_input = json.loads(instructor_task.task_input)
     except ValueError:
@@ -149,6 +151,7 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
         problem_url = task_input.get('problem_url')
         entrance_exam_url = task_input.get('entrance_exam_url')
         email_id = task_input.get('email_id')
+        course_id = task_input.get('course_key')
 
     if instructor_task.task_state == PROGRESS:
         # special message for providing progress updates:
@@ -192,6 +195,17 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
         else:  # num_succeeded < num_attempted
             # Translators: {action} is a past-tense verb that is localized separately. {succeeded} and {attempted} are counts.  # lint-amnesty, pylint: disable=line-too-long
             msg_format = _("Problem {action} for {succeeded} of {attempted} students")
+    elif course_id is not None:
+        # this reports on actions for a course as a whole
+        results = task_output.get('results', {})
+        assignments_count = results.get("assignments", 0)
+        grades_count = results.get("grades", 0)
+
+        msg_format = _("{grades_count} grades and {assignments_count} assignments updated or created").format(
+            grades_count=grades_count,
+            assignments_count=assignments_count,
+        )
+        succeeded = True
     elif email_id is not None:
         # this reports on actions on bulk emails
         if num_attempted == 0:

--- a/lms/static/js/instructor_dashboard/canvas_integration.js
+++ b/lms/static/js/instructor_dashboard/canvas_integration.js
@@ -1,0 +1,201 @@
+/* globals _, edx */
+
+(function($, _) {  // eslint-disable-line wrap-iife
+    'use strict';
+    var PendingInstructorTasks = function() {
+        return window.InstructorDashboard.util.PendingInstructorTasks;
+    };
+    var ReportDownloads = function() {
+        return window.InstructorDashboard.util.ReportDownloads;
+    };
+
+    var CanvasIntegration = (function() {
+        function tableify(data) {
+            var keys = Object.keys(data[0]);
+            var keysLookup = {};
+            keys.forEach(function(key, i) {
+                keysLookup[key] = i;
+            });
+
+            var rows = data.map(function(dict) {
+                var cols = keys.map(function(key) { return '<td>'.concat(dict[key], '</td>'); }).join('');
+                return '<tr>'.concat(cols, '</tr>');
+            }).join('');
+            var headerRow = '<tr>'.concat(keys.map(function(key) {
+                return '<th>'.concat(key, '</th>');
+            }).join(''), '</tr>');
+            return '<table>'.concat(headerRow, rows, '</table>');
+        }
+
+        function InstructorDashboardCanvasIntegration($section) {
+            this.$section = $section;
+            this.$section.data('wrapper', this);
+            var $results = this.$section.find('#results');
+            var $errors = this.$section.find('#errors');
+            var $loading = this.$section.find('#loading');
+            var $listEnrollmentsBtn = this.$section.find(
+          "input[name='list-canvas-enrollments']"
+        );
+            var $mergeCanvasEnrollmentsBtn = this.$section.find(
+          "input[name='merge-canvas-enrollments']"
+        );
+            var $overloadCanvasEnrollmentsBtn = this.$section.find(
+          "input[name='overload-canvas-enrollments']"
+        );
+            var $loadCanvasAssignmentsBtn = this.$section.find(
+          "input[name='load-canvas-assignments']"
+        );
+            var $listCanvasGradesBtn = this.$section.find("input[name='list-canvas-grades']");
+            var $canvasAssignSection = this.$section.find('#canvas-assignment-section');
+            var $pushAllEdxGradesBtn = this.$section.find("input[name='push-all-edx-grades']");
+            var $assignmentInput = this.$section.find("select[name='assignment-id']");
+            this.report_downloads = new (ReportDownloads())(this.$section);
+            this.instructor_tasks = new (PendingInstructorTasks())(this.$section);
+
+            var setLoading = function() {
+                $errors.html('');
+                $results.html('');
+                $loading.show();
+            };
+            var stopLoading = function() {
+                $loading.hide();
+            };
+            var showErrors = function(error) {
+                $loading.hide();
+                $results.html('');
+                // xss-lint: disable=javascript-jquery-html
+                $errors.html('Error: <pre>'.concat(JSON.stringify(error, null, 4), '</pre>'));
+            };
+            var showResults = function(title, asTable) {
+                return function(data) {
+                    var results = asTable ? tableify(data) : (
+              '<pre>'.concat(JSON.stringify(data, null, 4), '</pre>')
+            );
+                    $loading.hide();
+                    $errors.html('');
+                    // xss-lint: disable=javascript-jquery-html
+                    $results.html(title.concat(': ', results));
+                };
+            };
+
+            var mergeHandler = function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    url: url,
+                    data: {unenroll_current: $el.data('unenroll-current')}
+                }).then(
+            showResults('Status', false)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            };
+
+            $mergeCanvasEnrollmentsBtn.click(mergeHandler);
+            $overloadCanvasEnrollmentsBtn.click(mergeHandler);
+            $listEnrollmentsBtn.click(function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'GET',
+                    dataType: 'json',
+                    url: url
+                }).then(
+            showResults('Enrollments on Canvas', true)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+            $loadCanvasAssignmentsBtn.click(function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                $canvasAssignSection.hide();
+                return $.ajax({
+                    type: 'GET',
+                    dataType: 'json',
+                    url: url
+                }).then(function(assignments) {
+                    $canvasAssignSection.show();
+                    $assignmentInput.empty();
+                    assignments.forEach(function(assignment) {
+                        var $option = $('<option />');
+                        $option.val(assignment.id).text(assignment.name);
+                        $assignmentInput.append($option);
+                    });
+                }).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+            $listCanvasGradesBtn.click(function(event) {
+                var assignmentId = parseInt($assignmentInput.val());
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'GET',
+                    dataType: 'json',
+                    url: url,
+                    data: {
+                        assignment_id: assignmentId
+                    }
+                }).then(
+            showResults('Grades on Canvas', false)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+            $pushAllEdxGradesBtn.click(function(event) {
+                var $el = $(event.target);
+                var url = $el.data('endpoint');
+                setLoading();
+                return $.ajax({
+                    type: 'POST',
+                    dataType: 'json',
+                    url: url
+                }).then(
+            showResults('Grade Update Results', false)
+          ).fail(
+            showErrors
+          ).always(
+            stopLoading
+          );
+            });
+        }
+        InstructorDashboardCanvasIntegration.prototype.onClickTitle = function() {
+            this.instructor_tasks.task_poller.start();
+            return this.report_downloads.downloads_poller.start();
+        };
+
+        InstructorDashboardCanvasIntegration.prototype.onExit = function() {
+            this.instructor_tasks.task_poller.stop();
+            return this.report_downloads.downloads_poller.stop();
+        };
+
+        return InstructorDashboardCanvasIntegration;
+    }());
+
+    _.defaults(window, {
+        InstructorDashboard: {}
+    });
+
+    _.defaults(window.InstructorDashboard, {
+        sections: {}
+    });
+
+    _.defaults(window.InstructorDashboard.sections, {
+        CanvasIntegration: CanvasIntegration
+    });
+}).call(this, $, _);

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -170,6 +170,9 @@ such that the value can be defined later than this assignment (file load order).
                 constructor: window.InstructorDashboard.sections.ECommerce,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#e-commerce')
             }, {
+                constructor: window.InstructorDashboard.sections.CanvasIntegration,
+                $element: idashContent.find('.' + CSS_IDASH_SECTION + '#canvas_integration')
+            }, {
                 constructor: window.InstructorDashboard.sections.Membership,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#membership')
             }, {

--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -50,7 +50,8 @@
             enableColumnReorder: false,
             autoHeight: true,
             rowHeight: 100,
-            forceFitColumns: true
+            forceFitColumns: true,
+            enableTextSelectionOnCells: true
         };
         columns = [
             {
@@ -97,7 +98,14 @@
         */
 
                 name: gettext('Submitted'),
-                minWidth: 120
+                minWidth: 120,
+                formatter: function(row, cell, value) {
+                  if (!value) {
+                    return value
+                  }
+                  var fromNow = moment(value).fromNow()
+                  return value.concat("<br />(", fromNow, ")")
+                }
             }, {
                 id: 'duration_sec',
                 field: 'duration_sec',
@@ -491,7 +499,8 @@
                 enableCellNavigation: true,
                 enableColumnReorder: false,
                 rowHeight: 30,
-                forceFitColumns: true
+                forceFitColumns: true,
+                enableTextSelectionOnCells: true
             };
             columns = [
                 {

--- a/lms/templates/instructor/instructor_dashboard_2/canvas_integration.html
+++ b/lms/templates/instructor/instructor_dashboard_2/canvas_integration.html
@@ -1,0 +1,58 @@
+<%page args="section_data" expression_filter="h"/>
+<%namespace name='static' file='../../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<section>
+    <h4 class="hd hd-4">${_("Canvas enrollments")}</h4>
+    <p>
+
+        <input type="button" name="list-canvas-enrollments" value="List enrollments on Canvas"
+               data-endpoint="${ section_data['list_canvas_enrollments_url'] }"/>
+    </p>
+    <p>
+        <input type="button" name="merge-canvas-enrollments" value="Merge enrollment list using Canvas"
+               data-endpoint="${ section_data['add_canvas_enrollments_url'] }" data-unenroll-current="false"/>
+        <input type="button" name="overload-canvas-enrollments" value="Overload enrollment list using Canvas"
+               data-endpoint="${ section_data['add_canvas_enrollments_url'] }" data-unenroll-current="true"/>
+    </p>
+    <hr/>
+    <h4 class="hd hd-4">${_("Export grades to Canvas")}</h4>
+    <p>
+        <input type="button" name="push-all-edx-grades"
+               value="Push all MITx grades to Canvas"
+               data-endpoint="${ section_data['push_edx_grades_url'] }"
+        />&nbsp;
+        <input type="button" name="load-canvas-assignments"
+               value="Load Canvas assignments"
+               data-endpoint="${ section_data['list_canvas_assignments_url'] }"
+        />
+    </p>
+    <p id="canvas-assignment-section" style="display: none;">
+        <label for="assignment_id">Assignment id: </label>
+        <select name="assignment-id" id="assignment_id"></select>
+        <br /><br />
+        <input type="button" name="list-canvas-grades"
+               value="List Canvas assignment grades"
+               data-endpoint="${ section_data['list_canvas_grades_url'] }"
+        />
+    </p>
+    <hr/>
+    <div id="loading" style="display: none;">
+        <img src="${static.url('images/spinner.gif')}" alt="Loading..." />
+    </div>
+    <div id="errors" class="errors"></div>
+    <div id="results"></div>
+%if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
+  <div class="running-tasks-container action-type-container">
+    <h3 class="hd hd-3">${_("Pending Tasks")}</h3>
+    <div class="running-tasks-section">
+      <p>${_("The status for any active tasks appears in a table below.")} </p>
+      <br />
+      <div class="running-tasks-table" data-endpoint="${ section_data['list_instructor_tasks_url'] }"></div>
+    </div>
+    <div class="no-pending-tasks-message"></div>
+  </div>
+%endif
+</section>

--- a/lms/templates/instructor/instructor_dashboard_2/html-datatable.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/html-datatable.underscore
@@ -1,0 +1,16 @@
+<p>
+    <h2><%- title %></h2>
+    <table class="stat_table"><tr>
+        <%_.forEach(header, function (h) {%>
+            <th><%- h %></th>
+        <%})%>
+        </tr>
+        <%_.forEach(data, function (row) {%>
+            <tr>
+                <%_.forEach(row, function (value) {%>
+                    <td><%- value %></td>
+                <%})%>
+            </tr>
+        <%})%>
+    </table>
+</p>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -80,7 +80,7 @@ from openedx.core.djangolib.markup import HTML
 
 ## Include Underscore templates
 <%block name="header_extras">
-% for template_name in ["cohorts", "discussions", "enrollment-code-lookup-links", "cohort-editor", "cohort-group-header", "cohort-selector", "cohort-form", "notification", "cohort-state", "divided-discussions-inline", "divided-discussions-course-wide", "cohort-discussions-category", "cohort-discussions-subcategory", "certificate-allowlist", "certificate-allowlist-editor", "certificate-bulk-allowlist", "certificate-invalidation", "membership-list-widget"]:
+% for template_name in ["cohorts", "discussions", "enrollment-code-lookup-links", "cohort-editor", "cohort-group-header", "cohort-selector", "cohort-form", "notification", "cohort-state", "divided-discussions-inline", "divided-discussions-course-wide", "cohort-discussions-category", "cohort-discussions-subcategory", "certificate-allowlist", "certificate-allowlist-editor", "certificate-bulk-allowlist", "certificate-invalidation", "membership-list-widget", "html-datatable"]:
 <script type="text/template" id="${template_name}-tpl">
   <%static:include path="instructor/instructor_dashboard_2/${template_name}.underscore" />
 </script>


### PR DESCRIPTION
### Related Ticket:
https://github.com/mitodl/open-edx-plugins/issues/6

**Side Note 1:** Once this PR is merged we'll be adding only that code which would be part of this PR(and probably future cherry-picks) instead of [this whole chunk](https://github.com/mitodl/edx-platform/commit/b61152ac70)


### What's this PR do?
- It removes the `remote_gradebook` and its dependencies
- It extracts the `canvas_integration` into a separate plugin
- Keeps only `canvas_integration` plugin supporting counterpart(Mostly instructor functionality that the canvas depended upon)


### How to test?
This might need a counterpart a plugin to completely test. The counterpart to test this PR with is currently a WIP (https://github.com/mitodl/open-edx-plugins/pull/8). Once that PR is finalized we can test this one:
- Setup this branch of the platform
- Install the plugin from https://github.com/mitodl/open-edx-plugins/pull/8 (e.g. put that plugin inside dir in `/src` dir & then move to `make lms-shell` & then `pip install /edx/src/dist/<plugin>`) OR any other way suitable
- `make dev.provision.lms`/`make lms-restart`
- Open any course as Admin & open instructor tab
- You should see a `Canvas` tab under the instructor tab
- Clicking `Canvas` tab should enable you to test the canvas functionality