### PR TITLE
refactor: Refactor & add required rapid response counterpart

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
+++ b/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
@@ -1,0 +1,30 @@
+<%page args="section_data" expression_filter="h"/>
+<%!
+from itertools import groupby
+
+from django.utils.translation import ugettext as _
+from django.urls import reverse
+
+from lms.djangoapps.courseware.courses import get_course_by_id
+from ol_openedx_rapid_response_reports.utils import get_display_name_from_usage_key
+%>
+
+
+<div>
+    <% course = get_course_by_id(section_data['course_key'], depth=None) %>
+    % for date,runs in groupby(section_data['problem_runs'],key=lambda x:x['created'].date()):
+    <ul>
+        <li>${date.strftime('%Y/%m/%d')}</li>
+        <ul>
+            % for run in runs:
+            <li>${get_display_name_from_usage_key(run['problem_usage_key'], course)} - ${run['created'].strftime('%I:%M:%S %p')}:
+                <a type="button" class="btn-link"
+                   href="${reverse('get_rapid_response_report', kwargs={'course_id': section_data['course_key'], 'run_id': run['id']})}">
+                    ${_("Download")}
+                </a>
+            </li>
+            % endfor
+        </ul>
+    </ul>
+    % endfor
+</div>


### PR DESCRIPTION
### Related Ticket:
https://github.com/mitodl/edx-platform/issues/273

### Description
We did some platform changes to use some of the rapid response functionality & later on we used to cherry-pick that with every Open edX release. Now we are trying to refactor and migrate all this code into a plugin in https://github.com/mitodl/open-edx-plugins.

### What this PR does?
- It picks only the relevant parts of the commit(https://github.com/mitodl/edx-platform/commit/bbe7d0628d2f4f0800406f18b65d066525f766ce)
- It's currently in progress, But if we can move all the code to the plugin then this PR will contain the remaining counterpart.


### How to test?
This should be tested once we create a rapid response plugin in https://github.com/mitodl/open-edx-plugins.