### PR TITLE
fix: Inconsistent PipelineCachedStorage usages

### DIFF
--- a/cms/envs/devstack_optimized.py
+++ b/cms/envs/devstack_optimized.py
@@ -33,7 +33,7 @@ DEBUG = True
 REQUIRE_DEBUG = False
 
 # Fetch static files out of the pipeline's static root
-STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+STATICFILES_STORAGE = 'pipeline.storage.PipelineManifestStorage'
 
 #  Serve static files at /static directly from the staticfiles directory under test root.
 # Note: optimized files for testing are generated with settings from test_static_optimized

--- a/lms/envs/devstack_optimized.py
+++ b/lms/envs/devstack_optimized.py
@@ -34,7 +34,7 @@ DEBUG = True
 REQUIRE_DEBUG = False
 
 # Fetch static files out of the pipeline's static root
-STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+STATICFILES_STORAGE = 'pipeline.storage.PipelineManifestStorage'
 
 #  Serve static files at /static directly from the staticfiles directory under test root.
 # Note: optimized files for testing are generated with settings from test_static_optimized

--- a/openedx/core/lib/django_require/staticstorage.py
+++ b/openedx/core/lib/django_require/staticstorage.py
@@ -2,13 +2,13 @@
 :class:`~django_require.staticstorage.OptimizedCachedRequireJsStorage`
 """
 
-from pipeline.storage import PipelineCachedStorage
+from pipeline.storage import PipelineManifestStorage
 from require.storage import OptimizedFilesMixin
 
 from openedx.core.storage import PipelineForgivingMixin
 
 
-class OptimizedCachedRequireJsStorage(OptimizedFilesMixin, PipelineForgivingMixin, PipelineCachedStorage):
+class OptimizedCachedRequireJsStorage(OptimizedFilesMixin, PipelineForgivingMixin, PipelineManifestStorage):
     """
     Custom storage backend that is used by Django-require.
     """


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description
`PipelineCachedStorage` class from `dango-pipeline` has been refactored to be used only below `Django 3.1` as mentioned in https://github.com/jazzband/django-pipeline/pull/725. This change was published with version `2.0.5`. Since the Maple release, the `edx-platform` has been updated to use `Django 3.2.x` and that's why we see the pipeline import creating issues.

## Supporting information
- `django-pipeline` Now recommends using `PipelineManifestStorage` instead of `PipelineCachedStorage` as it is mentioned in the [commit description](https://github.com/jazzband/django-pipeline/commit/08b2a4efd36f8bc3a5e386a5ab41ec9c68855afe#diff-8a24db16746e894c7a861e371d1c356f46f5b3cf52e5fdb7db13aa3b8cee8603)

## How to reproduce
- To reproduce this issue locally you can got to shell e.g. `make lms-shell` and run `paver update_assets lms --settings=test_static_optimized` and you should be able to notice this import error
```
from pipeline.storage import PipelineCachedStorage
ImportError: cannot import name 'PipelineCachedStorage' from 'pipeline.storage' (/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pipeline/storage.py)
```

## Testing instructions
- As a first step you should try and reproduce the error
- Shift to this branch of the platform and now run `paver update_assets lms --settings=test_static_optimized` again and this time the paver should be successful.