### PR TITLE
feat: Add support for Rapid Response Reports plugin (#275)

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
+++ b/lms/templates/instructor/instructor_dashboard_2/rapid_response.html
@@ -1,0 +1,30 @@
+<%page args="section_data" expression_filter="h"/>
+<%!
+from itertools import groupby
+
+from django.utils.translation import ugettext as _
+from django.urls import reverse
+
+from lms.djangoapps.courseware.courses import get_course_by_id
+from ol_openedx_rapid_response_reports.utils import get_display_name_from_usage_key
+%>
+
+
+<div>
+    <% course = get_course_by_id(section_data['course_key'], depth=None) %>
+    % for date,runs in groupby(section_data['problem_runs'],key=lambda x:x['created'].date()):
+    <ul>
+        <li>${date.strftime('%Y/%m/%d')}</li>
+        <ul>
+            % for run in runs:
+            <li>${get_display_name_from_usage_key(run['problem_usage_key'], course)} - ${run['created'].strftime('%I:%M:%S %p')}:
+                <a type="button" class="btn-link"
+                   href="${reverse('get_rapid_response_report', kwargs={'course_id': section_data['course_key'], 'run_id': run['id']})}">
+                    ${_("Download")}
+                </a>
+            </li>
+            % endfor
+        </ul>
+    </ul>
+    % endfor
+</div>


### PR DESCRIPTION
## Related Ticket:
None

Recently noticed that Rapid Responses Tab wasn't working as expected, After looking around I notice that we somehow had our recent commit for `Rapid Response Reports support` removed from the `mitx/maple` branch. The commit was added in https://github.com/mitodl/edx-platform/pull/275. 

So to fix that I've cherry-picked that commit in this PR again & tested it.

For any testing instructions, Visit https://github.com/mitodl/edx-platform/pull/275.