### PR TITLE
feat: external plugin integration in instructor dashboard

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -545,15 +545,15 @@ SYSTEM_WIDE_ROLE_CLASSES = ENV_TOKENS.get('SYSTEM_WIDE_ROLE_CLASSES') or SYSTEM_
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
 
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)
+
 ####################### Plugin Settings ##########################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded
 
 add_plugins(__name__, ProjectType.CMS, SettingsType.PRODUCTION)
-
-########################## Derive Any Derived Settings  #######################
-
-derive_settings(__name__)
 
 ############# CORS headers for cross-domain requests #################
 if FEATURES.get('ENABLE_CORS_HEADERS'):

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -71,7 +71,7 @@ import six
 import social_django
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
-from django.contrib.auth import logout
+from django.contrib.auth import logout  # lint-amnesty, pylint: disable=unused-import
 from django.core.mail.message import EmailMessage
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
@@ -98,7 +98,7 @@ from common.djangoapps.third_party_auth.utils import (
     user_exists,
 )
 from common.djangoapps.track import segment
-from common.djangoapps.util.json_request import JsonResponse
+from common.djangoapps.util.json_request import JsonResponse  # lint-amnesty, pylint: disable=unused-import
 
 from . import provider
 

--- a/lms/djangoapps/instructor/constants.py
+++ b/lms/djangoapps/instructor/constants.py
@@ -1,0 +1,9 @@
+"""
+Constants used by Instructor.
+"""
+
+# this is the UserPreference key for the user's recipient invoice copy
+INVOICE_KEY = 'pref-invoice-copy'
+
+# external plugins (if any) will use this constant to return context to instructor dashboard
+INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME = 'instructor_dashboard'

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -23,6 +23,7 @@ from common.djangoapps.student.tests.factories import AdminFactory, CourseAccess
 from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import XssTestMixin
+from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
@@ -581,6 +582,21 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
         # assert we don't get a 500 error
         assert 200 == response.status_code
+
+    @patch("lms.djangoapps.instructor.views.instructor_dashboard.get_plugins_view_context")
+    def test_external_plugin_integration(self, mock_get_plugins_view_context):
+        """
+        Tests that whether context from plugins is being reflected/added in instructor dashboard.
+        """
+        test_studio_url = get_studio_url(self.course, 'course')
+
+        context = {
+            'studio_url': test_studio_url
+        }
+        mock_get_plugins_view_context.return_value = context
+
+        response = self.client.get(self.url)
+        self.assertContains(response, test_studio_url)
 
 
 @ddt.ddt

--- a/lms/djangoapps/instructor/views/__init__.py
+++ b/lms/djangoapps/instructor/views/__init__.py
@@ -1,4 +1,0 @@
-"""
-This is the UserPreference key for the user's recipient invoice copy
-"""
-INVOICE_KEY = 'pref-invoice-copy'

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -86,6 +86,7 @@ from lms.djangoapps.discussion.django_comment_client.utils import (
 )
 from lms.djangoapps.instructor import enrollment
 from lms.djangoapps.instructor.access import ROLES, allow_access, list_with_level, revoke_access, update_forum_role
+from lms.djangoapps.instructor.constants import INVOICE_KEY
 from lms.djangoapps.instructor.enrollment import (
     enroll_email,
     get_email_params,
@@ -94,7 +95,6 @@ from lms.djangoapps.instructor.enrollment import (
     send_mail_to_student,
     unenroll_email,
 )
-from lms.djangoapps.instructor.views import INVOICE_KEY
 from lms.djangoapps.instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
 from lms.djangoapps.instructor_analytics import basic as instructor_analytics_basic, csvs as instructor_analytics_csvs
 from lms.djangoapps.instructor_task import api as task_api

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -23,7 +23,6 @@ from django.views.decorators.http import require_POST
 from edx_proctoring.api import does_backend_support_onboarding
 from edx_django_utils.plugins import get_plugins_view_context
 from edx_when.api import is_enabled_for_course
-from edx_django_utils.plugins import get_plugins_view_context
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from xblock.field_data import DictFieldData

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -23,6 +23,7 @@ from django.views.decorators.http import require_POST
 from edx_proctoring.api import does_backend_support_onboarding
 from edx_django_utils.plugins import get_plugins_view_context
 from edx_when.api import is_enabled_for_course
+from edx_django_utils.plugins import get_plugins_view_context
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from xblock.field_data import DictFieldData
@@ -52,6 +53,7 @@ from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
+from lms.djangoapps.instructor.constants import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
 from openedx.core.djangoapps.course_groups.cohorts import DEFAULT_COHORT_NAME, get_course_cohorts, is_course_cohorted
 from openedx.core.djangoapps.discussions.config.waffle_utils import legacy_discussion_experience_enabled
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, CourseDiscussionSettings
@@ -267,6 +269,14 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
     }
+
+    context_from_plugins = get_plugins_view_context(
+        ProjectType.LMS,
+        INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME,
+        context
+    )
+
+    context.update(context_from_plugins)
 
     return render_to_response('instructor/instructor_dashboard_2/instructor_dashboard_2.html', context)
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -956,16 +956,16 @@ DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
 
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)
+
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded
 
 # Load production.py in plugins
 add_plugins(__name__, ProjectType.LMS, SettingsType.PRODUCTION)
-
-########################## Derive Any Derived Settings  #######################
-
-derive_settings(__name__)
 
 ############## Settings for Completion API #########################
 

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -130,7 +130,7 @@ from openedx.core.djangolib.markup import HTML
           <% is_hidden = section_data.get('is_hidden', False) %>
           <section id="${ section_data['section_key'] }" class="idash-section${' hidden' if hidden else ''}" aria-labelledby="header-${section_data['section_key']}">
               <h3 class="hd hd-3" id="header-${ section_data['section_key'] }">${ section_data['section_display_name'] }</h3>
-              <%include file="${ section_data['section_key'] }.html" args="section_data=section_data" />
+              <%include file="${ section_data.get('template_path_prefix', '') }${ section_data['section_key'] }.html" args="section_data=section_data" />
           </section>
           % endfor
         </section>


### PR DESCRIPTION
## Description

There are plugins which return context which is then embedded/used accordingly. So in instructor dashboard we need a flow/function which get/fetches the context from external plugins and updates the existing context with the context returned from external plugins. This has been done via a function **get_plugins_view_context** of **edx_django_utils.plugins**. A separate constant file has been created in instructor which consists of a constant: **INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME**. Any external plugin which uses this constant, will return context to instructor dashboard.

While installing an external plugin, all the settings should be derived first and **add_plugins** function should be called afterwards in **lms -> envs -> production.py** but currently **add_plugins** function is being called before **derive_settings** function, hence their order has been switched. Same goes for **cms -> envs -> production.py**

In **lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html**, we include the html files of sections from relative path, but in case of plugin, we need to give absolute path, as plugin's html file is inside plugin so in order to give absolute path we need to add a prefix **"/"**.

## Supporting information

None

## Testing instructions

- Any external plugin which uses the constant **INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME** to return any context,  will be received in instructor dashboard.
- If we call the **add_plugins** function before **derive_settings** function, then an exception can be seen while adding plugin's template in app_dirs.
- If we call the **add_plugins** function after **derive_settings** function, then plugin's template is successfully added in app_dirs.
- If we don't place a prefix **"/"** while including a html file from some other directory/app then an exception can be seen as it automatically adds relative path to it while including and the file can not be found on this path because plugin's html file is inside plugin templates.
- If we place a prefix **"/"** while including a html file from some other directory/app then it includes the file successfully as now absolute path is provided by appending this prefix.  

## Deadline

None

## Other information

None
