### PR TITLE
fix: remove slashmark

### DIFF
--- a/common/static/common/js/components/BlockBrowser/data/api/client.js
+++ b/common/static/common/js/components/BlockBrowser/data/api/client.js
@@ -21,7 +21,7 @@ export function buildQueryString(data) {
 }
 
 export const getCourseBlocks = courseId => fetch(
-  `${COURSE_BLOCKS_API}/?${buildQueryString({
+  `${COURSE_BLOCKS_API}?${buildQueryString({
     course_id: courseId,
     all_blocks: true,
     depth: 'all',


### PR DESCRIPTION
<!--

🍁🍁
🍁🍁🍁🍁         🍁 Note: the Maple master branch has been created.  Please consider whether your change
    🍁🍁🍁🍁     should also be applied to Maple. If so, make another pull request against the
🍁🍁🍁🍁         open-release/maple.master branch, or ping @nedbat for help or questions.
🍁🍁

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Related Ticket:
https://github.com/mitodl/mitxpro/issues/2332

## Description
This PR cherry-picks one of the fixes merged in master in the `Download Report` section on `Instructor Dashboard` where a double slash(`//`) in `Course Blocks` API call was ending in a 404 in the backend.

## Supporting information
There were some other PRs(https://github.com/openedx/edx-platform/pull/29699 & https://github.com/openedx/edx-platform/pull/29742) opened up to fix the issue at hand, but we are going with the one that has already been merged in master.

## Testing instructions
- Same as mentioned in https://github.com/openedx/edx-platform/pull/29699 except that you need to be on the maple branch. `xpro/maple` in this specific case.
