### PR TITLE
feat: add canvas integration support

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2302,6 +2302,7 @@ def _list_instructor_tasks(request, course_id):
 
     Internal function with common code for both DRF and and tradition views.
     """
+    include_canvas = request.GET.get('include_canvas') is not None
     course_id = CourseKey.from_string(course_id)
     params = getattr(request, 'query_params', request.POST)
     problem_location_str = strip_if_string(params.get('problem_location_str', False))
@@ -2325,6 +2326,11 @@ def _list_instructor_tasks(request, course_id):
         else:
             # Specifying for single problem's history
             tasks = task_api.get_instructor_task_history(course_id, module_state_key)
+    elif include_canvas:
+        tasks = task_api.get_running_instructor_canvas_tasks(
+            course_id,
+            user=request.user
+        )
     else:
         # If no problem or student, just get currently running tasks
         tasks = task_api.get_running_instructor_tasks(course_id)

--- a/lms/djangoapps/instructor_task/views.py
+++ b/lms/djangoapps/instructor_task/views.py
@@ -138,7 +138,9 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
 
     student = None
     problem_url = None
+    entrance_exam_url = None
     email_id = None
+    course_id = None
     try:
         task_input = json.loads(instructor_task.task_input)
     except ValueError:
@@ -149,6 +151,7 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
         problem_url = task_input.get('problem_url')
         entrance_exam_url = task_input.get('entrance_exam_url')
         email_id = task_input.get('email_id')
+        course_id = task_input.get('course_key')
 
     if instructor_task.task_state == PROGRESS:
         # special message for providing progress updates:
@@ -192,6 +195,17 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
         else:  # num_succeeded < num_attempted
             # Translators: {action} is a past-tense verb that is localized separately. {succeeded} and {attempted} are counts.  # lint-amnesty, pylint: disable=line-too-long
             msg_format = _("Problem {action} for {succeeded} of {attempted} students")
+    elif course_id is not None:
+        # this reports on actions for a course as a whole
+        results = task_output.get('results', {})
+        assignments_count = results.get("assignments", 0)
+        grades_count = results.get("grades", 0)
+
+        msg_format = _("{grades_count} grades and {assignments_count} assignments updated or created").format(
+            grades_count=grades_count,
+            assignments_count=assignments_count,
+        )
+        succeeded = True
     elif email_id is not None:
         # this reports on actions on bulk emails
         if num_attempted == 0:

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -170,6 +170,9 @@ such that the value can be defined later than this assignment (file load order).
                 constructor: window.InstructorDashboard.sections.ECommerce,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#e-commerce')
             }, {
+                constructor: window.InstructorDashboard.sections.CanvasIntegration,
+                $element: idashContent.find('.' + CSS_IDASH_SECTION + '#canvas_integration')
+            }, {
                 constructor: window.InstructorDashboard.sections.Membership,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#membership')
             }, {

--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -50,7 +50,8 @@
             enableColumnReorder: false,
             autoHeight: true,
             rowHeight: 100,
-            forceFitColumns: true
+            forceFitColumns: true,
+            enableTextSelectionOnCells: true
         };
         columns = [
             {
@@ -97,7 +98,14 @@
         */
 
                 name: gettext('Submitted'),
-                minWidth: 120
+                minWidth: 120,
+                formatter: function(row, cell, value) {
+                  if (!value) {
+                    return value
+                  }
+                  var fromNow = moment(value).fromNow()
+                  return value.concat("<br />(", fromNow, ")")
+                }
             }, {
                 id: 'duration_sec',
                 field: 'duration_sec',
@@ -491,7 +499,8 @@
                 enableCellNavigation: true,
                 enableColumnReorder: false,
                 rowHeight: 30,
-                forceFitColumns: true
+                forceFitColumns: true,
+                enableTextSelectionOnCells: true
             };
             columns = [
                 {

--- a/lms/templates/instructor/instructor_dashboard_2/html-datatable.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/html-datatable.underscore
@@ -1,0 +1,16 @@
+<p>
+    <h2><%- title %></h2>
+    <table class="stat_table"><tr>
+        <%_.forEach(header, function (h) {%>
+            <th><%- h %></th>
+        <%})%>
+        </tr>
+        <%_.forEach(data, function (row) {%>
+            <tr>
+                <%_.forEach(row, function (value) {%>
+                    <td><%- value %></td>
+                <%})%>
+            </tr>
+        <%})%>
+    </table>
+</p>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -80,7 +80,7 @@ from openedx.core.djangolib.markup import HTML
 
 ## Include Underscore templates
 <%block name="header_extras">
-% for template_name in ["cohorts", "discussions", "enrollment-code-lookup-links", "cohort-editor", "cohort-group-header", "cohort-selector", "cohort-form", "notification", "cohort-state", "divided-discussions-inline", "divided-discussions-course-wide", "cohort-discussions-category", "cohort-discussions-subcategory", "certificate-allowlist", "certificate-allowlist-editor", "certificate-bulk-allowlist", "certificate-invalidation", "membership-list-widget"]:
+% for template_name in ["cohorts", "discussions", "enrollment-code-lookup-links", "cohort-editor", "cohort-group-header", "cohort-selector", "cohort-form", "notification", "cohort-state", "divided-discussions-inline", "divided-discussions-course-wide", "cohort-discussions-category", "cohort-discussions-subcategory", "certificate-allowlist", "certificate-allowlist-editor", "certificate-bulk-allowlist", "certificate-invalidation", "membership-list-widget", "html-datatable"]:
 <script type="text/template" id="${template_name}-tpl">
   <%static:include path="instructor/instructor_dashboard_2/${template_name}.underscore" />
 </script>

--- a/xmodule/course_module.py
+++ b/xmodule/course_module.py
@@ -480,6 +480,13 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
         ),
         scope=Scope.settings
     )
+    canvas_course_id = Integer(
+        display_name=_("Canvas Course Id"),
+        help=_(
+            "The id for the corresponding course on Canvas"
+        ),
+        scope=Scope.settings
+    )
     enable_ccx = Boolean(
         # Translators: Custom Courses for edX (CCX) is an edX feature for re-using course content. CCX Coach is
         # a role created by a course Instructor to enable a person (the "Coach") to manage the custom course for


### PR DESCRIPTION
#### Related ticket
https://github.com/mitodl/edx-platform/issues/299

#### What this PR does?
- Cherry-picks the Canvas integration from Nutmeg to Olive (Mentioned in the ticket)
- Refactors the code a little to fix the conflicts

#### How should this be tested?

- Install https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_canvas_integration (Follow the readme instructions) or just `pip install ol-openedx-canvas-integration`
- Restart edx instance, notice you are able to see the `Canvas` tab under `Instructor Dashboard`
- Set canvas course id in your test course through Studio's Advanced Settings
- Make sure that all the Canvas functionality works fine (Functionality is mostly mentioned in https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_canvas_integration)
- You will need values for (You can ask for these keys from me or Devops folks):
    - `CANVAS_BASE_URL`
    - `CANVAS_ACCESS_TOKEN`

- Some more testing instructions are on https://github.com/mitodl/edx-platform/pull/274