### PR TITLE
feat: add canvas integration support (#300)

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2456,6 +2456,9 @@ def _list_instructor_tasks(request, course_id, serialize_data=None):
         else:
             # Specifying for single problem's history
             tasks = task_api.get_instructor_task_history(course_id, module_state_key)
+    elif request.GET.get('include_canvas') is not None:
+        from ol_openedx_canvas_integration.task_helpers import get_filtered_instructor_tasks  # pylint: disable=import-error
+        tasks = get_filtered_instructor_tasks(course_id, request.user)
     else:
         # If no problem or student, just get currently running tasks
         tasks = task_api.get_running_instructor_tasks(course_id)

--- a/lms/djangoapps/instructor_task/views.py
+++ b/lms/djangoapps/instructor_task/views.py
@@ -138,6 +138,7 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
 
     student = None
     problem_url = None
+    entrance_exam_url = None
     email_id = None
     try:
         task_input = json.loads(instructor_task.task_input)
@@ -192,6 +193,10 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
         else:  # num_succeeded < num_attempted
             # Translators: {action} is a past-tense verb that is localized separately. {succeeded} and {attempted} are counts.  # lint-amnesty, pylint: disable=line-too-long
             msg_format = _("Problem {action} for {succeeded} of {attempted} students")
+    elif task_input and task_input.get('course_key'):
+        from ol_openedx_canvas_integration.utils import get_task_output_formatted_message  # pylint: disable=import-error
+        msg_format = get_task_output_formatted_message(task_output)
+        succeeded = True
     elif email_id is not None:
         # this reports on actions on bulk emails
         if num_attempted == 0:

--- a/lms/djangoapps/instructor_task/views.py
+++ b/lms/djangoapps/instructor_task/views.py
@@ -140,6 +140,7 @@ def get_task_completion_info(instructor_task):  # lint-amnesty, pylint: disable=
     problem_url = None
     entrance_exam_url = None
     email_id = None
+    task_input = None
     try:
         task_input = json.loads(instructor_task.task_input)
     except ValueError:

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -177,6 +177,9 @@ such that the value can be defined later than this assignment (file load order).
                 constructor: window.InstructorDashboard.sections.ECommerce,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#e-commerce')
             }, {
+                constructor: window.InstructorDashboard.sections.CanvasIntegration,
+                $element: idashContent.find('.' + CSS_IDASH_SECTION + '#canvas_integration')
+            }, {
                 constructor: window.InstructorDashboard.sections.Membership,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#membership')
             }, {

--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -51,7 +51,8 @@
             enableColumnReorder: false,
             autoHeight: true,
             rowHeight: 100,
-            forceFitColumns: true
+            forceFitColumns: true,
+            enableTextSelectionOnCells: true
         };
         columns = [
             {
@@ -492,7 +493,8 @@
                 enableCellNavigation: true,
                 enableColumnReorder: false,
                 rowHeight: 30,
-                forceFitColumns: true
+                forceFitColumns: true,
+                enableTextSelectionOnCells: true
             };
             columns = [
                 {

--- a/lms/templates/instructor/instructor_dashboard_2/html-datatable.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/html-datatable.underscore
@@ -1,0 +1,16 @@
+<p>
+    <h2><%- title %></h2>
+    <table class="stat_table"><tr>
+        <%_.forEach(header, function (h) {%>
+            <th><%- h %></th>
+        <%})%>
+        </tr>
+        <%_.forEach(data, function (row) {%>
+            <tr>
+                <%_.forEach(row, function (value) {%>
+                    <td><%- value %></td>
+                <%})%>
+            </tr>
+        <%})%>
+    </table>
+</p>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -92,7 +92,7 @@ from openedx.core.djangolib.js_utils import (
 
 ## Include Underscore templates
 <%block name="header_extras">
-% for template_name in ["cohorts", "discussions", "enrollment-code-lookup-links", "cohort-editor", "cohort-group-header", "cohort-selector", "cohort-form", "notification", "cohort-state", "divided-discussions-inline", "divided-discussions-course-wide", "cohort-discussions-category", "cohort-discussions-subcategory", "certificate-allowlist", "certificate-allowlist-editor", "certificate-bulk-allowlist", "certificate-invalidation", "membership-list-widget"]:
+% for template_name in ["cohorts", "discussions", "enrollment-code-lookup-links", "cohort-editor", "cohort-group-header", "cohort-selector", "cohort-form", "notification", "cohort-state", "divided-discussions-inline", "divided-discussions-course-wide", "cohort-discussions-category", "cohort-discussions-subcategory", "certificate-allowlist", "certificate-allowlist-editor", "certificate-bulk-allowlist", "certificate-invalidation", "membership-list-widget", "html-datatable"]:
 <script type="text/template" id="${template_name}-tpl">
   <%static:include path="instructor/instructor_dashboard_2/${template_name}.underscore" />
 </script>


### PR DESCRIPTION
## Relevant ticket

https://github.com/mitodl/hq/issues/5862

## Description

Cherry-picked and resolved conflicts from https://github.com/mitodl/edx-platform/commit/7a2edd5d29ead6845cb33d2001746207cf696383

NOTE: I have reduced as much code and migrated it to (https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_canvas_integration) as much as possible.


## Testing instructions

- Setup your edX instance on this branch
- Setup the flag from https://github.com/mitodl/ol-infrastructure/pull/2777 to enable other settings because we have removed the Canvas ID field from course settings now
- Install the canvas plugin from https://github.com/mitodl/open-edx-plugins/pull/387
- Test the Canvas functionality (Reach out to me for a Canvas API token/key)

NOTE: I've removed some lines about displaying the time past time on the date column e.g. (`An hour ago`) since that was not needed or important enough to keep in our cherry-pick