### PR TITLE
fix: add potential webpack_loader utils issue fix

### DIFF
--- a/xmodule/util/builtin_assets.py
+++ b/xmodule/util/builtin_assets.py
@@ -5,7 +5,6 @@ These should not be used to support any XBlocks outside of edx-platform.
 """
 from pathlib import Path
 
-import webpack_loader
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -44,6 +43,7 @@ def add_webpack_js_to_fragment(fragment, bundle_name):
     """
     Add all JS webpack chunks to the supplied fragment.
     """
+    import webpack_loader.utils
     for chunk in webpack_loader.utils.get_files(bundle_name, None, 'DEFAULT'):
         if chunk['name'].endswith(('.js', '.js.gz')):
             fragment.add_javascript_url(chunk['url'])

--- a/xmodule/util/builtin_assets.py
+++ b/xmodule/util/builtin_assets.py
@@ -43,7 +43,7 @@ def add_webpack_js_to_fragment(fragment, bundle_name):
     """
     Add all JS webpack chunks to the supplied fragment.
     """
-    import webpack_loader.utils
-    for chunk in webpack_loader.utils.get_files(bundle_name, None, 'DEFAULT'):
+    from webpack_loader.utils import get_files
+    for chunk in get_files(bundle_name, None, 'DEFAULT'):
         if chunk['name'].endswith(('.js', '.js.gz')):
             fragment.add_javascript_url(chunk['url'])


### PR DESCRIPTION
## Issue
https://github.com/mitodl/hq/issues/6229

## Description

This PR introduces a potential fix for the webpack_loader utils issue in the mitx teak branch, which is currently used in mitx qa. The issue does not reproduce on the local setup; therefore, after merging and deploying this change, we need to test it on mitx qa where the issue occurs.

## Supporting information

https://github.com/mitodl/hq/issues/6229#issuecomment-3089425292

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.

- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
- If your [database migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) can't be rolled back easily.
